### PR TITLE
Cache reflection lookup when removing sublevels

### DIFF
--- a/src/main/java/com/maxenonyme/AbyssDimension/system/SubmarineLianaCommand.java
+++ b/src/main/java/com/maxenonyme/AbyssDimension/system/SubmarineLianaCommand.java
@@ -222,14 +222,16 @@ public final class SubmarineLianaCommand {
 
             ServerSubLevel subLevel = SubLevelAssemblyHelper.assembleBlocks(level, plotAnchor, segmentBlocks, bounds);
             if (subLevel == null) {
-                for (ServerSubLevel sub : assembledSubLevels) {
-                    try {
-                        java.lang.reflect.Method method = container.getClass().getMethod("removeSubLevel", dev.ryanhcode.sable.sublevel.SubLevel.class, Class.forName("dev.ryanhcode.sable.api.sublevel.SubLevelRemovalReason"));
-                        Class<?> enumCls = Class.forName("dev.ryanhcode.sable.api.sublevel.SubLevelRemovalReason");
-                        Object reason = enumCls.getEnumConstants()[0];
-                        method.invoke(container, sub, reason);
-                    } catch (Throwable ignored) {}
-                }
+                try {
+                    Class<?> reasonCls = Class.forName("dev.ryanhcode.sable.api.sublevel.SubLevelRemovalReason");
+                    java.lang.reflect.Method method = container.getClass().getMethod("removeSubLevel", dev.ryanhcode.sable.sublevel.SubLevel.class, reasonCls);
+                    Object reason = reasonCls.getEnumConstants()[0];
+                    for (ServerSubLevel sub : assembledSubLevels) {
+                        try {
+                            method.invoke(container, sub, reason);
+                        } catch (Throwable ignored) {}
+                    }
+                } catch (Throwable ignored) {}
                 rollback(level, originalStates);
                 return null;
             }
@@ -252,14 +254,16 @@ public final class SubmarineLianaCommand {
                     BoundingBox3i seedBounds = new BoundingBox3i(seedPos.getX(), seedPos.getY(), seedPos.getZ(), seedPos.getX(), seedPos.getY(), seedPos.getZ());
                     ServerSubLevel seedSubLevel = SubLevelAssemblyHelper.assembleBlocks(level, seedPos, List.of(seedPos), seedBounds);
                     if (seedSubLevel == null) {
-                        for (ServerSubLevel sub : assembledSubLevels) {
-                            try {
-                                java.lang.reflect.Method method = container.getClass().getMethod("removeSubLevel", dev.ryanhcode.sable.sublevel.SubLevel.class, Class.forName("dev.ryanhcode.sable.api.sublevel.SubLevelRemovalReason"));
-                                Class<?> enumCls = Class.forName("dev.ryanhcode.sable.api.sublevel.SubLevelRemovalReason");
-                                Object reason = enumCls.getEnumConstants()[0];
-                                method.invoke(container, sub, reason);
-                            } catch (Throwable ignored) {}
-                        }
+                        try {
+                            Class<?> reasonCls = Class.forName("dev.ryanhcode.sable.api.sublevel.SubLevelRemovalReason");
+                            java.lang.reflect.Method method = container.getClass().getMethod("removeSubLevel", dev.ryanhcode.sable.sublevel.SubLevel.class, reasonCls);
+                            Object reason = reasonCls.getEnumConstants()[0];
+                            for (ServerSubLevel sub : assembledSubLevels) {
+                                try {
+                                    method.invoke(container, sub, reason);
+                                } catch (Throwable ignored) {}
+                            }
+                        } catch (Throwable ignored) {}
                         rollback(level, originalStates);
                         return null;
                     }


### PR DESCRIPTION
Avoid repeated Class.forName and getMethod calls when rolling back assembled sublevels by resolving the SubLevelRemovalReason class and removeSubLevel Method once, then invoking the method for each sublevel. Keeps the same rollback behavior and exception suppression while reducing reflection overhead and duplicated code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache reflection lookups when rolling back assembled sublevels in `SubmarineLianaCommand`. Resolve `dev.ryanhcode.sable.api.sublevel.SubLevelRemovalReason` and the container’s `removeSubLevel` method once, then reuse for each sublevel to reduce reflection overhead while keeping rollback behavior and exception suppression unchanged.

<sup>Written for commit fe79afffbcfb6f75157d670605976992d0b2fd36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Maxenonyme/Create-Deep-Seas/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

