### PR TITLE
Persist lianas and plant physics; add UI/config

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [May 30, 2026] - Persistent Lianas, Fruit Reattachment & Configurable Oceans
+
+### Bug Fixes
+- **Lianas Surviving Reload:** Fixed creepvines breaking apart and floating to the surface after leaving and rejoining a world. Their topology (which segment anchors to the seabed, parent/child links, attached fruits) was never actually persisted — the spawn-time block-entity lookup silently failed, so nothing survived a reload. The full chain layout is now saved to a dedicated registry and every physics joint is rebuilt deterministically on load.
+- **No More Self-Fighting Lianas:** Fixed lianas jittering, folding and collapsing when bumped into after a reload. Each stacked liana block was running its own physics and stacking buoyancy/player forces several times over; only the segment's centre block now drives the simulation.
+- **Fruits Staying Attached:** Fixed creepvine fruits randomly dropping off on reload depending on chunk load order. Each fruit's rest position is now remembered and the fruit is snapped back into place before its joint is rebuilt, so it always reattaches where it belongs.
+
+### Configuration & User Interface
+- **Configurable Ocean Depth:** The Deeper Oceans feature is no longer locked to a fixed 10 blocks — a new `deeperOceansDepth` option (default 10, up to 256) lets you choose how far below vanilla the sea floor sits, with an in-config warning that large values can badly hurt world-generation and rendering performance.
+- **Deep Seas Welcome Screen:** Added a one-time welcome screen shown in front of the main menu, recommending you set up your Deep Seas preferences before diving in. It offers a button straight to the mod configuration and a "maybe later" button; either choice is remembered in the config TOML so it never shows again.
+
+### Under the Hood
+- **Reusable Plant Persistence:** Generalized the liana save system into a plant-agnostic `PlantPhysicsRegistry` that will back future physical plants, made it the single source of truth for segment topology, and dropped the redundant (and unreliable) block-entity NBT copy.
+
 ## [May 29, 2026] - Abyss Dimension, Physical Lianas & Big Optimizations
 
 ### New Blocks & Features

--- a/src/main/java/com/maxenonyme/AbyssDimension/block/entity/SubmarineLianaBlockEntity.java
+++ b/src/main/java/com/maxenonyme/AbyssDimension/block/entity/SubmarineLianaBlockEntity.java
@@ -17,14 +17,36 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.joml.Quaterniond;
 import org.joml.Vector3d;
+import org.joml.Vector3dc;
+import dev.ryanhcode.sable.api.physics.constraint.ConstraintJointAxis;
+import dev.ryanhcode.sable.api.physics.constraint.PhysicsConstraintHandle;
+import dev.ryanhcode.sable.api.physics.constraint.generic.GenericConstraintConfiguration;
+import java.util.EnumSet;
 import java.util.UUID;
 
 public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntitySubLevelActor {
     private UUID parentId;
-    private UUID childId;
     private UUID seedId;
     private boolean isController;
     private int worldLightLevel = 10;
+    private int segmentLen = 3;
+    private Vector3d groundAnchor = null;
+    private double seedLocalY = -1.0;
+    private Vector3d seedLocalAnchor = null;
+    private Vector3d seedOffset = null;
+    private int parentPlotX = -1;
+    private int parentPlotZ = -1;
+    private int childPlotX = -1;
+    private int childPlotZ = -1;
+    private int seedPlotX = -1;
+    private int seedPlotZ = -1;
+
+    private transient PhysicsConstraintHandle groundJoint = null;
+    private transient PhysicsConstraintHandle parentJoint = null;
+    private transient PhysicsConstraintHandle seedJoint = null;
+
+    private transient Vector3d restPos = null;
+    private transient Quaterniond restRot = null;
 
     private final ForceTotal forceTotal = new ForceTotal();
     private final ForceTotal parentForceTotal = new ForceTotal();
@@ -46,19 +68,99 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
         this.setChanged();
     }
 
-    public void setChild(UUID childId) {
-        this.childId = childId;
-        this.setChanged();
-    }
-
     public void setController(boolean controller) {
         this.isController = controller;
         this.setChanged();
     }
 
-    public void setSeed(UUID seedId) {
-        this.seedId = seedId;
+    public void setSegmentLen(int segmentLen) {
+        this.segmentLen = segmentLen;
         this.setChanged();
+    }
+
+    public void setGroundAnchor(Vector3d groundAnchor) {
+        this.groundAnchor = groundAnchor;
+        this.setChanged();
+    }
+
+    public void setSeed(UUID seedId, double localY) {
+        this.seedId = seedId;
+        this.seedLocalY = localY;
+        this.setChanged();
+    }
+
+    public void setSeed(UUID seedId, Vector3d seedLocalAnchor) {
+        this.seedId = seedId;
+        this.seedLocalAnchor = seedLocalAnchor;
+        this.setChanged();
+    }
+
+    public void setGroundJoint(PhysicsConstraintHandle groundJoint) {
+        this.groundJoint = groundJoint;
+    }
+
+    public void setParentJoint(PhysicsConstraintHandle parentJoint) {
+        this.parentJoint = parentJoint;
+    }
+
+    public void setSeedJoint(PhysicsConstraintHandle seedJoint) {
+        this.seedJoint = seedJoint;
+    }
+
+    public void setParentPlot(int x, int z) {
+        this.parentPlotX = x;
+        this.parentPlotZ = z;
+        this.setChanged();
+    }
+
+    public void setChildPlot(int x, int z) {
+        this.childPlotX = x;
+        this.childPlotZ = z;
+        this.setChanged();
+    }
+
+    public void setSeedPlot(int x, int z) {
+        this.seedPlotX = x;
+        this.seedPlotZ = z;
+        this.setChanged();
+    }
+
+    public boolean isController() {
+        return isController;
+    }
+
+    public boolean isGroundJointValid() {
+        return groundJoint != null && groundJoint.isValid();
+    }
+
+    public boolean isParentJointValid() {
+        return parentJoint != null && parentJoint.isValid();
+    }
+
+    public boolean hasParentPlot() {
+        return parentPlotX != -1 || parentId != null;
+    }
+
+    public int getSeedPlotX() {
+        return seedPlotX;
+    }
+
+    public int getSeedPlotZ() {
+        return seedPlotZ;
+    }
+
+    public boolean isSeedJointValid() {
+        return seedJoint != null && seedJoint.isValid();
+    }
+
+    private ServerSubLevel findSubLevelByPlot(ServerSubLevelContainer container, int plotX, int plotZ) {
+        if (plotX == -1) return null;
+        for (ServerSubLevel sub : container.getAllSubLevels()) {
+            if (sub.getPlot() != null && sub.getPlot().plotPos.x == plotX && sub.getPlot().plotPos.z == plotZ) {
+                return sub;
+            }
+        }
+        return null;
     }
 
     public int getWorldLightLevel() {
@@ -89,13 +191,201 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
 
     @Override
     public void sable$physicsTick(ServerSubLevel subLevel, RigidBodyHandle handle, double timeStep) {
+        // A segment sublevel holds one liana BlockEntity per stacked block, and every one is a
+        // physics actor. Only the block at the plot centre drives the segment, otherwise each BE
+        // would recreate its own joints and stack buoyancy/player forces N times — which makes the
+        // whole chain fight itself and jitter. The non-driver BEs just render and hold light.
+        if (!worldPosition.equals(subLevel.getPlot().getCenterBlock())) {
+            return;
+        }
+
+        if (this.parentPlotX == -1 && !this.isController && this.groundAnchor == null) {
+            com.maxenonyme.AbyssDimension.system.PlantPhysicsRegistry registry = com.maxenonyme.AbyssDimension.system.PlantPhysicsRegistry.get(subLevel.getLevel());
+            com.maxenonyme.AbyssDimension.system.PlantPhysicsRegistry.SegmentData data = registry.getSegment(subLevel.getPlot().plotPos.x, subLevel.getPlot().plotPos.z);
+            if (data != null) {
+                this.isController = data.root();
+                this.segmentLen = data.segmentLen();
+                if (data.hasGroundAnchor()) {
+                    this.groundAnchor = new Vector3d(data.groundX(), data.groundY(), data.groundZ());
+                }
+                this.parentPlotX = data.parentPlotX();
+                this.parentPlotZ = data.parentPlotZ();
+                this.childPlotX = data.childPlotX();
+                this.childPlotZ = data.childPlotZ();
+                this.seedPlotX = data.attachmentPlotX();
+                this.seedPlotZ = data.attachmentPlotZ();
+                if (data.hasAttachment()) {
+                    this.seedLocalAnchor = new Vector3d(data.attachmentLocalX(), data.attachmentLocalY(), data.attachmentLocalZ());
+                    this.seedOffset = new Vector3d(data.attachmentOffsetX(), data.attachmentOffsetY(), data.attachmentOffsetZ());
+                }
+            }
+        }
         handle.getLinearVelocity(linearVelocity);
         handle.getAngularVelocity(angularVelocity);
 
         totalForce.set(0, 0, 0);
         totalTorque.set(0, 0, 0);
 
+
+        if (isController && groundAnchor != null && (groundJoint == null || !groundJoint.isValid())) {
+            ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer.getContainer(subLevel.getLevel());
+            if (container != null) {
+                Vector3d localAnchor0 = new Vector3d(worldPosition.getX() + 0.5, worldPosition.getY(), worldPosition.getZ() + 0.5);
+                groundJoint = container.physicsSystem().getPipeline().addConstraint(
+                        subLevel,
+                        null,
+                        new GenericConstraintConfiguration(
+                                localAnchor0,
+                                new Vector3d(groundAnchor),
+                                new Quaterniond(),
+                                new Quaterniond(),
+                                EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y, ConstraintJointAxis.LINEAR_Z, ConstraintJointAxis.ANGULAR_Y)
+                        )
+                );
+                if (groundJoint != null) {
+                    groundJoint.setContactsEnabled(false);
+                    container.physicsSystem().getPipeline().wakeUp(subLevel);
+                }
+            }
+        }
+
+        if ((parentId != null || parentPlotX != -1) && (parentJoint == null || !parentJoint.isValid())) {
+            ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer.getContainer(subLevel.getLevel());
+            if (container != null) {
+                ServerSubLevel parentSub = null;
+                if (parentPlotX != -1) {
+                    parentSub = findSubLevelByPlot(container, parentPlotX, parentPlotZ);
+                }
+                if (parentSub == null && parentId != null) {
+                    parentSub = (ServerSubLevel) container.getSubLevel(parentId);
+                }
+                if (parentSub != null && parentSub.getPlot() != null) {
+                    BlockPos parentPlotAnchor = parentSub.getPlot().getCenterBlock();
+                    BlockPos currentPlotAnchor = subLevel.getPlot().getCenterBlock();
+                    dev.ryanhcode.sable.companion.math.BoundingBox3ic parentBounds = parentSub.getPlot().getBoundingBox();
+                    int parentLenVal = parentBounds.maxY() - parentBounds.minY() + 1;
+                    Vector3d localAnchorCurrent = new Vector3d(parentPlotAnchor.getX() + 0.5, parentPlotAnchor.getY() + parentLenVal - 0.05, parentPlotAnchor.getZ() + 0.5);
+                    Vector3d localAnchorNext = new Vector3d(currentPlotAnchor.getX() + 0.5, currentPlotAnchor.getY() + 0.05, currentPlotAnchor.getZ() + 0.5);
+                    
+                    parentJoint = container.physicsSystem().getPipeline().addConstraint(
+                            parentSub,
+                            subLevel,
+                            new GenericConstraintConfiguration(
+                                    localAnchorCurrent,
+                                    localAnchorNext,
+                                    new Quaterniond(),
+                                    new Quaterniond(),
+                                    EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y, ConstraintJointAxis.LINEAR_Z, ConstraintJointAxis.ANGULAR_Y)
+                            )
+                    );
+                    if (parentJoint != null) {
+                        parentJoint.setContactsEnabled(false);
+                        container.physicsSystem().getPipeline().wakeUp(subLevel);
+                        container.physicsSystem().getPipeline().wakeUp(parentSub);
+                    }
+                }
+            }
+        }
+
+
+        if ((seedId != null || seedPlotX != -1) && (seedJoint == null || !seedJoint.isValid())) {
+            Vector3d localAnchorCurrent = null;
+            if (seedLocalAnchor != null) {
+                BlockPos segmentPlotAnchor = subLevel.getPlot().getCenterBlock();
+                localAnchorCurrent = new Vector3d(
+                        segmentPlotAnchor.getX() + seedLocalAnchor.x,
+                        segmentPlotAnchor.getY() + seedLocalAnchor.y,
+                        segmentPlotAnchor.getZ() + seedLocalAnchor.z
+                );
+            } else if (seedLocalY >= 0) {
+                BlockPos segmentPlotAnchor = subLevel.getPlot().getCenterBlock();
+                localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.9, segmentPlotAnchor.getY() + seedLocalY + 0.5, segmentPlotAnchor.getZ() + 0.5);
+            }
+
+            if (localAnchorCurrent != null) {
+                ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer.getContainer(subLevel.getLevel());
+                if (container != null) {
+                    ServerSubLevel seedSub = null;
+                    if (seedPlotX != -1) {
+                        seedSub = findSubLevelByPlot(container, seedPlotX, seedPlotZ);
+                    }
+                    if (seedSub == null && seedId != null) {
+                        seedSub = (ServerSubLevel) container.getSubLevel(seedId);
+                    }
+                    if (seedSub != null && seedSub.getPlot() != null) {
+                        // The seed sublevel can load before this segment and fall under gravity; a
+                        // joint created then would lock it at the fallen spot. Snap it back to its
+                        // rest offset from the segment (zeroing velocity) before binding, so it always
+                        // reattaches where it belongs regardless of chunk load order.
+                        if (seedOffset != null) {
+                            Vector3d seedTarget = new Vector3d(subLevel.logicalPose().position()).add(seedOffset);
+                            RigidBodyHandle seedHandle = RigidBodyHandle.of(seedSub);
+                            if (seedHandle != null) {
+                                Vector3d sv = new Vector3d();
+                                Vector3d sa = new Vector3d();
+                                seedHandle.getLinearVelocity(sv);
+                                seedHandle.getAngularVelocity(sa);
+                                seedHandle.addLinearAndAngularVelocity(sv.negate(), sa.negate());
+                            }
+                            seedSub.logicalPose().position().set(seedTarget);
+                            seedSub.updateLastPose();
+                            container.physicsSystem().getPipeline().teleport(seedSub, seedTarget, new Quaterniond());
+                        }
+
+                        BlockPos seedPlotAnchor = seedSub.getPlot().getCenterBlock();
+                        Vector3d localAnchorNext = new Vector3d(seedPlotAnchor.getX() + 0.5, seedPlotAnchor.getY() + 0.9, seedPlotAnchor.getZ() + 0.5);
+                        
+                        seedJoint = container.physicsSystem().getPipeline().addConstraint(
+                                subLevel,
+                                seedSub,
+                                new GenericConstraintConfiguration(
+                                        localAnchorCurrent,
+                                        localAnchorNext,
+                                        new Quaterniond(),
+                                        new Quaterniond(),
+                                        EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y, ConstraintJointAxis.LINEAR_Z)
+                                )
+                        );
+                        if (seedJoint != null) {
+                            seedJoint.setContactsEnabled(false);
+                            container.physicsSystem().getPipeline().wakeUp(subLevel);
+                            container.physicsSystem().getPipeline().wakeUp(seedSub);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (restPos == null) {
+            restPos = new Vector3d(subLevel.logicalPose().position());
+            restRot = new Quaterniond(subLevel.logicalPose().orientation());
+        }
+
+        boolean anchored;
+        if (isController) {
+            anchored = isGroundJointValid();
+        } else if (hasParentPlot()) {
+            anchored = isParentJointValid();
+        } else {
+            anchored = true;
+        }
+
+        if (!anchored) {
+            handle.addLinearAndAngularVelocity(tempVec.set(linearVelocity).negate(), tempVec2.set(angularVelocity).negate());
+            subLevel.logicalPose().position().set(restPos);
+            subLevel.logicalPose().orientation().set(restRot);
+            subLevel.updateLastPose();
+            ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer.getContainer(subLevel.getLevel());
+            if (container != null) {
+                container.physicsSystem().getPipeline().teleport(subLevel, restPos, restRot);
+            }
+            return;
+        }
+
         double mass = subLevel.getMassTracker().getMass();
+        if (mass < 1.0) {
+            mass = segmentLen * 10.0;
+        }
         double lianaBuoyancy = mass * (9.81 + 2.0);
         totalForce.add(0, lianaBuoyancy, 0);
 
@@ -106,11 +396,31 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
         double swayFreq = 1.0;
         double swayAmp = 1.5;
         double time = subLevel.getLevel().getGameTime() * timeStep;
-        double waveSway = Math.sin(time * swayFreq + worldPosition.getX() * 0.15 + worldPosition.getZ() * 0.15) * swayAmp;
+        double waveSway = Math.sin(time * swayFreq + worldPosition.getX() * 0.15 + worldPosition.getZ() * 0.15)
+                * swayAmp;
         totalForce.add(waveSway, 0, 0);
 
+        Vector3dc subPos = subLevel.logicalPose().position();
+        for (net.minecraft.world.entity.player.Player player : subLevel.getLevel().players()) {
+            double dx = subPos.x() - player.getX();
+            double dy = subPos.y() - (player.getY() + player.getEyeHeight() * 0.5);
+            double dz = subPos.z() - player.getZ();
+            double distSqr = dx * dx + dy * dy + dz * dz;
+            if (distSqr < 3.0) {
+                double dist = Math.sqrt(distSqr);
+                if (dist > 0.01) {
+                    double forceScale = (2.4 - dist) * 50.0;
+                    double playerSpeed = player.getDeltaMovement().length();
+                    double speedBonus = Math.min(playerSpeed * 100.0, 120.0);
+                    tempVec.set(dx, dy, dz).normalize().mul((forceScale + speedBonus) * mass);
+                    totalForce.add(tempVec);
+                }
+            }
+        }
+
         if (parentId != null) {
-            ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer.getContainer(subLevel.getLevel());
+            ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer
+                    .getContainer(subLevel.getLevel());
             if (container != null) {
                 ServerSubLevel parentSubLevel = (ServerSubLevel) container.getSubLevel(parentId);
                 if (parentSubLevel != null) {
@@ -130,7 +440,8 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
                     if (parentHandle != null) {
                         parentForceTotal.reset();
                         tempVec2.set(totalTorque).negate();
-                        parentForceTotal.applyLinearAndAngularImpulse(JOMLConversion.ZERO, parentSubLevel.logicalPose().transformNormalInverse(tempVec2, tempVec2).mul(timeStep));
+                        parentForceTotal.applyLinearAndAngularImpulse(JOMLConversion.ZERO,
+                                parentSubLevel.logicalPose().transformNormalInverse(tempVec2, tempVec2).mul(timeStep));
                         parentHandle.applyForcesAndReset(parentForceTotal);
                     }
                 }
@@ -158,30 +469,50 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
         forceTotal.applyImpulseAtPoint(
                 subLevel,
                 JOMLConversion.atCenterOf(worldPosition),
-                subLevel.logicalPose().transformNormalInverse(totalForce, tempVec).mul(timeStep)
-        );
-        forceTotal.applyLinearAndAngularImpulse(JOMLConversion.ZERO, subLevel.logicalPose().transformNormalInverse(totalTorque, tempVec).mul(timeStep));
+                subLevel.logicalPose().transformNormalInverse(totalForce, tempVec).mul(timeStep));
+        forceTotal.applyLinearAndAngularImpulse(JOMLConversion.ZERO,
+                subLevel.logicalPose().transformNormalInverse(totalTorque, tempVec).mul(timeStep));
         handle.applyForcesAndReset(forceTotal);
     }
 
-
+    // Topology (controller/parent/ground/attachment) is owned by PlantPhysicsRegistry, not the
+    // block entity NBT: a segment holds one BE per stacked block and the embedded-level lookup that
+    // would set those fields at spawn isn't reliable, so the NBT copy was always empty. Only the
+    // rendered light level lives on the BE itself.
     @Override
     protected void saveAdditional(CompoundTag tag, HolderLookup.Provider registries) {
         super.saveAdditional(tag, registries);
-        tag.putBoolean("Controller", isController);
         tag.putInt("WorldLight", worldLightLevel);
-        if (parentId != null) tag.putUUID("ParentId", parentId);
-        if (childId != null) tag.putUUID("ChildId", childId);
-        if (seedId != null) tag.putUUID("SeedId", seedId);
     }
 
     @Override
     protected void loadAdditional(CompoundTag tag, HolderLookup.Provider registries) {
         super.loadAdditional(tag, registries);
-        isController = tag.getBoolean("Controller");
-        if (tag.contains("WorldLight")) worldLightLevel = tag.getInt("WorldLight");
-        if (tag.hasUUID("ParentId")) parentId = tag.getUUID("ParentId");
-        if (tag.hasUUID("ChildId")) childId = tag.getUUID("ChildId");
-        if (tag.hasUUID("SeedId")) seedId = tag.getUUID("SeedId");
+        if (tag.contains("WorldLight"))
+            worldLightLevel = tag.getInt("WorldLight");
+    }
+
+    public Vector3d getGroundAnchor() {
+        return groundAnchor;
+    }
+
+    public int getParentPlotX() {
+        return parentPlotX;
+    }
+
+    public int getParentPlotZ() {
+        return parentPlotZ;
+    }
+
+    public int getChildPlotX() {
+        return childPlotX;
+    }
+
+    public int getChildPlotZ() {
+        return childPlotZ;
+    }
+
+    public int getSegmentLen() {
+        return segmentLen;
     }
 }

--- a/src/main/java/com/maxenonyme/AbyssDimension/system/LianaLODOptimizer.java
+++ b/src/main/java/com/maxenonyme/AbyssDimension/system/LianaLODOptimizer.java
@@ -113,10 +113,7 @@ public final class LianaLODOptimizer {
         }
 
         if (!candidates.isEmpty()) {
-            candidates.sort(Comparator.comparingDouble(c -> c.minDistanceSqr));
-            int limit = Math.min(5, candidates.size());
-            for (int i = 0; i < limit; i++) {
-                WakeupCandidate candidate = candidates.get(i);
+            for (WakeupCandidate candidate : candidates) {
                 SablePhysicsHelper.setAsleep(candidate.handle, false);
                 awakeSubLevels.add(candidate.sub.getUniqueId());
             }

--- a/src/main/java/com/maxenonyme/AbyssDimension/system/PlantPhysicsRegistry.java
+++ b/src/main/java/com/maxenonyme/AbyssDimension/system/PlantPhysicsRegistry.java
@@ -1,0 +1,128 @@
+package com.maxenonyme.AbyssDimension.system;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.saveddata.SavedData;
+import net.minecraft.world.level.storage.DimensionDataStorage;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Per-dimension persistence for physics-driven plants (lianas today, other plants later).
+ *
+ * A plant is a chain of physics sublevels: each "segment" sublevel is anchored either to the world
+ * (the root) or to its parent segment, and may carry one attachment sublevel (a fruit/seed). Sable
+ * never serialises its physics joints, so on reload a segment has to rebuild every joint from
+ * scratch — and the segment's own BlockEntity NBT can't be trusted for that (a segment holds one
+ * BlockEntity per stacked block, only one of which is the driver). This registry is the single
+ * source of truth that lets each segment recover its role and neighbours, keyed by the segment's
+ * plot position, which is stable across save/load.
+ */
+public class PlantPhysicsRegistry extends SavedData {
+    private static final String NAME = "plant_physics_registry";
+
+    public record PlotKey(int x, int z) {}
+
+    /** Everything a plant segment needs to rebuild itself after a reload. */
+    public record SegmentData(
+            int plotX, int plotZ,
+            boolean root,
+            boolean hasGroundAnchor,
+            double groundX, double groundY, double groundZ,
+            int parentPlotX, int parentPlotZ,
+            int childPlotX, int childPlotZ,
+            int attachmentPlotX, int attachmentPlotZ,
+            double attachmentLocalX, double attachmentLocalY, double attachmentLocalZ,
+            double attachmentOffsetX, double attachmentOffsetY, double attachmentOffsetZ,
+            int segmentLen
+    ) {
+        public boolean hasAttachment() {
+            return attachmentPlotX != -1;
+        }
+    }
+
+    private final Map<PlotKey, SegmentData> segments = new HashMap<>();
+
+    public PlantPhysicsRegistry() {}
+
+    public static PlantPhysicsRegistry get(ServerLevel level) {
+        DimensionDataStorage storage = level.getDataStorage();
+        return storage.computeIfAbsent(new SavedData.Factory<>(
+                PlantPhysicsRegistry::new,
+                PlantPhysicsRegistry::load,
+                null
+        ), NAME);
+    }
+
+    public static PlantPhysicsRegistry load(CompoundTag tag, HolderLookup.Provider provider) {
+        PlantPhysicsRegistry registry = new PlantPhysicsRegistry();
+        ListTag list = tag.getList("Segments", Tag.TAG_COMPOUND);
+        for (int i = 0; i < list.size(); i++) {
+            CompoundTag s = list.getCompound(i);
+            SegmentData data = new SegmentData(
+                    s.getInt("plotX"), s.getInt("plotZ"),
+                    s.getBoolean("root"),
+                    s.getBoolean("hasGround"),
+                    s.getDouble("groundX"), s.getDouble("groundY"), s.getDouble("groundZ"),
+                    s.getInt("parentX"), s.getInt("parentZ"),
+                    s.getInt("childX"), s.getInt("childZ"),
+                    s.getInt("attachX"), s.getInt("attachZ"),
+                    s.getDouble("attachLocalX"), s.getDouble("attachLocalY"), s.getDouble("attachLocalZ"),
+                    s.getDouble("attachOffX"), s.getDouble("attachOffY"), s.getDouble("attachOffZ"),
+                    s.getInt("segmentLen")
+            );
+            registry.segments.put(new PlotKey(data.plotX(), data.plotZ()), data);
+        }
+        return registry;
+    }
+
+    @Override
+    public CompoundTag save(CompoundTag tag, HolderLookup.Provider provider) {
+        ListTag list = new ListTag();
+        for (SegmentData d : segments.values()) {
+            CompoundTag s = new CompoundTag();
+            s.putInt("plotX", d.plotX());
+            s.putInt("plotZ", d.plotZ());
+            s.putBoolean("root", d.root());
+            s.putBoolean("hasGround", d.hasGroundAnchor());
+            s.putDouble("groundX", d.groundX());
+            s.putDouble("groundY", d.groundY());
+            s.putDouble("groundZ", d.groundZ());
+            s.putInt("parentX", d.parentPlotX());
+            s.putInt("parentZ", d.parentPlotZ());
+            s.putInt("childX", d.childPlotX());
+            s.putInt("childZ", d.childPlotZ());
+            s.putInt("attachX", d.attachmentPlotX());
+            s.putInt("attachZ", d.attachmentPlotZ());
+            s.putDouble("attachLocalX", d.attachmentLocalX());
+            s.putDouble("attachLocalY", d.attachmentLocalY());
+            s.putDouble("attachLocalZ", d.attachmentLocalZ());
+            s.putDouble("attachOffX", d.attachmentOffsetX());
+            s.putDouble("attachOffY", d.attachmentOffsetY());
+            s.putDouble("attachOffZ", d.attachmentOffsetZ());
+            s.putInt("segmentLen", d.segmentLen());
+            list.add(s);
+        }
+        tag.put("Segments", list);
+        return tag;
+    }
+
+    public void putSegment(SegmentData data) {
+        segments.put(new PlotKey(data.plotX(), data.plotZ()), data);
+        setDirty();
+    }
+
+    public SegmentData getSegment(int plotX, int plotZ) {
+        return segments.get(new PlotKey(plotX, plotZ));
+    }
+
+    public void removeSegment(int plotX, int plotZ) {
+        if (segments.remove(new PlotKey(plotX, plotZ)) != null) {
+            setDirty();
+        }
+    }
+}

--- a/src/main/java/com/maxenonyme/AbyssDimension/system/SubmarineLianaCommand.java
+++ b/src/main/java/com/maxenonyme/AbyssDimension/system/SubmarineLianaCommand.java
@@ -187,6 +187,19 @@ public final class SubmarineLianaCommand {
         }
     }
 
+    private static void removeSubLevels(ServerSubLevelContainer container, List<ServerSubLevel> subLevels) {
+        try {
+            Class<?> reasonCls = Class.forName("dev.ryanhcode.sable.api.sublevel.SubLevelRemovalReason");
+            java.lang.reflect.Method method = ServerSubLevelContainer.class.getMethod("removeSubLevel", dev.ryanhcode.sable.sublevel.SubLevel.class, reasonCls);
+            Object reason = reasonCls.getEnumConstants()[0];
+            for (ServerSubLevel sub : subLevels) {
+                try {
+                    method.invoke(container, sub, reason);
+                } catch (Throwable ignored) {}
+            }
+        } catch (Throwable ignored) {}
+    }
+
     private static List<ServerSubLevel> spawnLianaChain(ServerLevel level, ServerSubLevelContainer container, BlockPos basePos, int length) {
         if (level.getBlockState(basePos.above(1)).is(LianaRegistry.LIANA_BLOCK.get())) {
             return null;
@@ -194,10 +207,33 @@ public final class SubmarineLianaCommand {
         int numSegments = (length + SEGMENT_SIZE - 1) / SEGMENT_SIZE;
         ServerSubLevel[] segments = new ServerSubLevel[numSegments];
         UUID[] segmentIds = new UUID[numSegments];
+        int[] seedPlotXForSeg = new int[numSegments];
+        int[] seedPlotZForSeg = new int[numSegments];
+        Vector3d[] seedLocalForSeg = new Vector3d[numSegments];
+        Vector3d[] seedOffsetForSeg = new Vector3d[numSegments];
+        java.util.Arrays.fill(seedPlotXForSeg, -1);
+        java.util.Arrays.fill(seedPlotZForSeg, -1);
         double currentY = basePos.getY() + 1.5;
 
         java.util.Map<BlockPos, net.minecraft.world.level.block.state.BlockState> originalStates = new java.util.HashMap<>();
         List<ServerSubLevel> assembledSubLevels = new ArrayList<>();
+
+        Random random = new Random();
+        List<Integer> seedIndices = new ArrayList<>();
+        if (length > 1) {
+            int maxFruits = Math.min(2, length - 1);
+            int fruitsToSpawn = random.nextInt(maxFruits + 1);
+            while (seedIndices.size() < fruitsToSpawn) {
+                int randIdx = random.nextInt(length - 1) + 2;
+                if (!seedIndices.contains(randIdx)) {
+                    seedIndices.add(randIdx);
+                }
+            }
+        }
+
+        List<Integer> directions = new ArrayList<>(List.of(0, 1, 2, 3));
+        java.util.Collections.shuffle(directions, random);
+        int spawnedFruitCount = 0;
 
         for (int i = 0; i < numSegments; i++) {
             int segmentStart = i * SEGMENT_SIZE;
@@ -222,16 +258,7 @@ public final class SubmarineLianaCommand {
 
             ServerSubLevel subLevel = SubLevelAssemblyHelper.assembleBlocks(level, plotAnchor, segmentBlocks, bounds);
             if (subLevel == null) {
-                try {
-                    Class<?> reasonCls = Class.forName("dev.ryanhcode.sable.api.sublevel.SubLevelRemovalReason");
-                    java.lang.reflect.Method method = container.getClass().getMethod("removeSubLevel", dev.ryanhcode.sable.sublevel.SubLevel.class, reasonCls);
-                    Object reason = reasonCls.getEnumConstants()[0];
-                    for (ServerSubLevel sub : assembledSubLevels) {
-                        try {
-                            method.invoke(container, sub, reason);
-                        } catch (Throwable ignored) {}
-                    }
-                } catch (Throwable ignored) {}
+                removeSubLevels(container, assembledSubLevels);
                 rollback(level, originalStates);
                 return null;
             }
@@ -247,36 +274,59 @@ public final class SubmarineLianaCommand {
 
             for (int j = 0; j < segmentLen; j++) {
                 int blockIndex = segmentStart + j + 1;
-                if (blockIndex % 5 == 0) {
-                    BlockPos seedPos = basePos.above(blockIndex).east(1);
+                if (seedIndices.contains(blockIndex)) {
+                    int dir = directions.get(spawnedFruitCount);
+                    spawnedFruitCount++;
+
+                    BlockPos seedPos;
+                    Vector3d seedFinalPos;
+                    Vector3d localAnchorCurrent;
+                    Vector3d localAnchorOffset;
+
+                    BlockPos segmentPlotAnchor = subLevel.getPlot().getCenterBlock();
+
+                    if (dir == 0) {
+                        seedPos = basePos.above(blockIndex).east(1);
+                        seedFinalPos = new Vector3d(finalPos.x + 0.4, finalPos.y + j - 0.4, finalPos.z);
+                        localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.9, segmentPlotAnchor.getY() + j + 0.5, segmentPlotAnchor.getZ() + 0.5);
+                        localAnchorOffset = new Vector3d(0.9, j + 0.5, 0.5);
+                    } else if (dir == 1) {
+                        seedPos = basePos.above(blockIndex).west(1);
+                        seedFinalPos = new Vector3d(finalPos.x - 0.4, finalPos.y + j - 0.4, finalPos.z);
+                        localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.1, segmentPlotAnchor.getY() + j + 0.5, segmentPlotAnchor.getZ() + 0.5);
+                        localAnchorOffset = new Vector3d(0.1, j + 0.5, 0.5);
+                    } else if (dir == 2) {
+                        seedPos = basePos.above(blockIndex).south(1);
+                        seedFinalPos = new Vector3d(finalPos.x, finalPos.y + j - 0.4, finalPos.z + 0.4);
+                        localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.5, segmentPlotAnchor.getY() + j + 0.5, segmentPlotAnchor.getZ() + 0.9);
+                        localAnchorOffset = new Vector3d(0.5, j + 0.5, 0.9);
+                    } else {
+                        seedPos = basePos.above(blockIndex).north(1);
+                        seedFinalPos = new Vector3d(finalPos.x, finalPos.y + j - 0.4, finalPos.z - 0.4);
+                        localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.5, segmentPlotAnchor.getY() + j + 0.5, segmentPlotAnchor.getZ() + 0.1);
+                        localAnchorOffset = new Vector3d(0.5, j + 0.5, 0.1);
+                    }
+
                     originalStates.putIfAbsent(seedPos, level.getBlockState(seedPos));
                     level.setBlock(seedPos, LianaRegistry.CREEPVINE_SEED.get().defaultBlockState(), 3);
                     BoundingBox3i seedBounds = new BoundingBox3i(seedPos.getX(), seedPos.getY(), seedPos.getZ(), seedPos.getX(), seedPos.getY(), seedPos.getZ());
                     ServerSubLevel seedSubLevel = SubLevelAssemblyHelper.assembleBlocks(level, seedPos, List.of(seedPos), seedBounds);
                     if (seedSubLevel == null) {
-                        try {
-                            Class<?> reasonCls = Class.forName("dev.ryanhcode.sable.api.sublevel.SubLevelRemovalReason");
-                            java.lang.reflect.Method method = container.getClass().getMethod("removeSubLevel", dev.ryanhcode.sable.sublevel.SubLevel.class, reasonCls);
-                            Object reason = reasonCls.getEnumConstants()[0];
-                            for (ServerSubLevel sub : assembledSubLevels) {
-                                try {
-                                    method.invoke(container, sub, reason);
-                                } catch (Throwable ignored) {}
-                            }
-                        } catch (Throwable ignored) {}
+                        removeSubLevels(container, assembledSubLevels);
                         rollback(level, originalStates);
                         return null;
                     }
                     assembledSubLevels.add(seedSubLevel);
+                    seedPlotXForSeg[i] = seedSubLevel.getPlot().plotPos.x;
+                    seedPlotZForSeg[i] = seedSubLevel.getPlot().plotPos.z;
+                    seedLocalForSeg[i] = localAnchorOffset;
+                    seedOffsetForSeg[i] = new Vector3d(seedFinalPos).sub(finalPos);
 
-                    Vector3d seedFinalPos = new Vector3d(finalPos.x + 0.4, finalPos.y + j - 0.4, finalPos.z);
                     seedSubLevel.logicalPose().position().set(seedFinalPos);
                     seedSubLevel.updateLastPose();
                     container.physicsSystem().getPipeline().teleport(seedSubLevel, seedFinalPos, new Quaterniond());
 
-                    BlockPos segmentPlotAnchor = subLevel.getPlot().getCenterBlock();
                     BlockPos seedPlotAnchor = seedSubLevel.getPlot().getCenterBlock();
-                    Vector3d localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.9, segmentPlotAnchor.getY() + j + 0.5, segmentPlotAnchor.getZ() + 0.5);
                     Vector3d localAnchorNext = new Vector3d(seedPlotAnchor.getX() + 0.5, seedPlotAnchor.getY() + 0.9, seedPlotAnchor.getZ() + 0.5);
 
                     PhysicsConstraintHandle seedJoint = container.physicsSystem().getPipeline().addConstraint(
@@ -296,7 +346,9 @@ public final class SubmarineLianaCommand {
 
                     net.minecraft.world.level.block.entity.BlockEntity rawBe = subLevel.getPlot().getEmbeddedLevelAccessor().getBlockEntity(segmentPlotAnchor);
                     if (rawBe instanceof SubmarineLianaBlockEntity lianaBe) {
-                        lianaBe.setSeed(seedSubLevel.getUniqueId());
+                        lianaBe.setSeed(seedSubLevel.getUniqueId(), localAnchorOffset);
+                        lianaBe.setSeedJoint(seedJoint);
+                        lianaBe.setSeedPlot(seedSubLevel.getPlot().plotPos.x, seedSubLevel.getPlot().plotPos.z);
                     }
                 }
             }
@@ -306,15 +358,55 @@ public final class SubmarineLianaCommand {
 
         for (int i = 0; i < numSegments; i++) {
             ServerSubLevel current = segments[i];
+            int segmentLen = Math.min(length, (i + 1) * SEGMENT_SIZE) - (i * SEGMENT_SIZE);
+            boolean isController = (i == 0);
+            Vector3d ground = isController
+                    ? new Vector3d(basePos.getX() + 0.5, basePos.getY() + 1.0, basePos.getZ() + 0.5)
+                    : null;
+            int parentPlotX = (i > 0) ? segments[i - 1].getPlot().plotPos.x : -1;
+            int parentPlotZ = (i > 0) ? segments[i - 1].getPlot().plotPos.z : -1;
+            int childPlotX = (i < numSegments - 1) ? segments[i + 1].getPlot().plotPos.x : -1;
+            int childPlotZ = (i < numSegments - 1) ? segments[i + 1].getPlot().plotPos.z : -1;
+
+            Vector3d seedLocal = seedLocalForSeg[i];
+            Vector3d seedOffset = seedOffsetForSeg[i];
+            PlantPhysicsRegistry.get(level).putSegment(new PlantPhysicsRegistry.SegmentData(
+                    current.getPlot().plotPos.x,
+                    current.getPlot().plotPos.z,
+                    isController,
+                    ground != null,
+                    ground != null ? ground.x : 0.0,
+                    ground != null ? ground.y : 0.0,
+                    ground != null ? ground.z : 0.0,
+                    parentPlotX, parentPlotZ,
+                    childPlotX, childPlotZ,
+                    seedPlotXForSeg[i], seedPlotZForSeg[i],
+                    seedLocal != null ? seedLocal.x : 0.0,
+                    seedLocal != null ? seedLocal.y : 0.0,
+                    seedLocal != null ? seedLocal.z : 0.0,
+                    seedOffset != null ? seedOffset.x : 0.0,
+                    seedOffset != null ? seedOffset.y : 0.0,
+                    seedOffset != null ? seedOffset.z : 0.0,
+                    segmentLen
+            ));
+
             BlockPos plotAnchor = current.getPlot().getCenterBlock();
             net.minecraft.world.level.block.entity.BlockEntity rawBe = current.getPlot().getEmbeddedLevelAccessor().getBlockEntity(plotAnchor);
             if (rawBe instanceof SubmarineLianaBlockEntity be) {
-                be.setController(i == 0);
+                be.setController(isController);
+                be.setSegmentLen(segmentLen);
+                if (ground != null) {
+                    be.setGroundAnchor(ground);
+                }
                 if (i > 0) {
                     be.setParent(segmentIds[i - 1]);
+                    be.setParentPlot(parentPlotX, parentPlotZ);
                 }
                 if (i < numSegments - 1) {
-                    be.setChild(segmentIds[i + 1]);
+                    be.setChildPlot(childPlotX, childPlotZ);
+                }
+                if (seedPlotXForSeg[i] != -1) {
+                    be.setSeedPlot(seedPlotXForSeg[i], seedPlotZForSeg[i]);
                 }
             }
         }
@@ -336,6 +428,10 @@ public final class SubmarineLianaCommand {
             );
             if (groundJoint != null) {
                 groundJoint.setContactsEnabled(false);
+            }
+            net.minecraft.world.level.block.entity.BlockEntity rawBe0 = segments[0].getPlot().getEmbeddedLevelAccessor().getBlockEntity(plotAnchor0);
+            if (rawBe0 instanceof SubmarineLianaBlockEntity be0) {
+                be0.setGroundJoint(groundJoint);
             }
         }
 
@@ -360,6 +456,10 @@ public final class SubmarineLianaCommand {
             );
             if (joint != null) {
                 joint.setContactsEnabled(false);
+            }
+            net.minecraft.world.level.block.entity.BlockEntity rawBeNext = next.getPlot().getEmbeddedLevelAccessor().getBlockEntity(nextPlotAnchor);
+            if (rawBeNext instanceof SubmarineLianaBlockEntity beNext) {
+                beNext.setParentJoint(joint);
             }
         }
 

--- a/src/main/java/com/maxenonyme/createsubmarine/CreateSubmarineClient.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/CreateSubmarineClient.java
@@ -41,6 +41,9 @@ public final class CreateSubmarineClient {
 
         modEventBus.addListener(WatermarkOverlay::register);
 
+        NeoForge.EVENT_BUS.addListener(
+                com.maxenonyme.createsubmarine.submarine.client.DeepSeasWelcomeScreen::onScreenOpening);
+
         NeoForge.EVENT_BUS.register(SubmarineFogHandler.class);
         NeoForge.EVENT_BUS.register(SubLevelCrackRenderer.class);
         NeoForge.EVENT_BUS.register(PDAManager.GameEvents.class);

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/client/DeepSeasWelcomeScreen.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/client/DeepSeasWelcomeScreen.java
@@ -1,0 +1,115 @@
+package com.maxenonyme.createsubmarine.submarine.client;
+
+import com.maxenonyme.createsubmarine.CreateSubmarine;
+import com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.FormattedCharSequence;
+import net.neoforged.fml.ModList;
+import net.neoforged.neoforge.client.event.ScreenEvent;
+import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
+
+import java.util.List;
+
+/**
+ * One-time welcome shown in front of the main menu, recommending the player set up their Deep Seas
+ * preferences. Either button marks it acknowledged in the config TOML so it never shows again.
+ */
+public class DeepSeasWelcomeScreen extends Screen {
+    private static final int PANEL_BG = 0xE6101A22;
+    private static final int PANEL_ACCENT = 0xFF3FB6E0;
+    private static final int PANEL_BORDER = 0xFF2C5566;
+    private static final int TITLE_COLOR = 0xFF8FE0FF;
+    private static final int BODY_COLOR = 0xFFCEDDE4;
+
+    private final Screen titleScreen;
+
+    private List<FormattedCharSequence> messageLines = List.of();
+    private int panelX, panelY, panelW, panelH;
+
+    public DeepSeasWelcomeScreen(Screen titleScreen) {
+        super(Component.translatable("create_submarine.welcome.title"));
+        this.titleScreen = titleScreen;
+    }
+
+    /** Swap the main menu for the welcome screen the first time it opens, until acknowledged. */
+    public static void onScreenOpening(ScreenEvent.Opening event) {
+        if (SubmarineConfig.WELCOME_SCREEN_SEEN.get()) {
+            return;
+        }
+        if (event.getNewScreen() instanceof TitleScreen menu) {
+            event.setNewScreen(new DeepSeasWelcomeScreen(menu));
+        }
+    }
+
+    @Override
+    protected void init() {
+        panelW = Math.min(360, this.width - 40);
+        messageLines = this.font.split(Component.translatable("create_submarine.welcome.message"), panelW - 28);
+
+        int titleBlock = 12 + this.font.lineHeight + 10;
+        int bodyBlock = messageLines.size() * (this.font.lineHeight + 2);
+        panelH = titleBlock + bodyBlock + 12;
+
+        int buttonW = Math.min(170, (panelW - 8) / 2);
+        int gap = 8;
+        int blockH = panelH + 14 + 20;
+        panelX = (this.width - panelW) / 2;
+        panelY = (this.height - blockH) / 2;
+
+        int centerX = this.width / 2;
+        int buttonsY = panelY + panelH + 14;
+
+        addRenderableWidget(Button.builder(
+                        Component.translatable("create_submarine.welcome.configure"),
+                        b -> { acknowledge(); openConfig(); })
+                .bounds(centerX - gap / 2 - buttonW, buttonsY, buttonW, 20)
+                .build());
+
+        addRenderableWidget(Button.builder(
+                        Component.translatable("create_submarine.welcome.dismiss"),
+                        b -> { acknowledge(); this.minecraft.setScreen(titleScreen); })
+                .bounds(centerX + gap / 2, buttonsY, buttonW, 20)
+                .build());
+    }
+
+    @Override
+    public void render(GuiGraphics g, int mouseX, int mouseY, float partialTick) {
+        super.render(g, mouseX, mouseY, partialTick);
+
+        g.fill(panelX, panelY, panelX + panelW, panelY + panelH, PANEL_BG);
+        g.fill(panelX, panelY, panelX + panelW, panelY + 2, PANEL_ACCENT);
+        g.renderOutline(panelX, panelY, panelW, panelH, PANEL_BORDER);
+
+        int centerX = this.width / 2;
+        g.drawCenteredString(this.font, this.title, centerX, panelY + 12, TITLE_COLOR);
+
+        int ty = panelY + 12 + this.font.lineHeight + 10;
+        for (FormattedCharSequence line : messageLines) {
+            g.drawCenteredString(this.font, line, centerX, ty, BODY_COLOR);
+            ty += this.font.lineHeight + 2;
+        }
+    }
+
+    private void acknowledge() {
+        SubmarineConfig.WELCOME_SCREEN_SEEN.set(true);
+        SubmarineConfig.WELCOME_SCREEN_SEEN.save();
+    }
+
+    private void openConfig() {
+        ModList.get().getModContainerById(CreateSubmarine.MOD_ID).ifPresentOrElse(
+                mc -> mc.getCustomExtension(IConfigScreenFactory.class).ifPresentOrElse(
+                        factory -> this.minecraft.setScreen(factory.createScreen(mc, titleScreen)),
+                        () -> this.minecraft.setScreen(titleScreen)),
+                () -> this.minecraft.setScreen(titleScreen));
+    }
+
+    @Override
+    public void onClose() {
+        acknowledge();
+        this.minecraft.setScreen(titleScreen);
+    }
+}

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/config/SubmarineConfig.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/config/SubmarineConfig.java
@@ -13,6 +13,8 @@ public class SubmarineConfig {
     public static final ModConfigSpec.DoubleValue WATER_THRUSTER_POWER_MULTIPLIER;
     public static final ModConfigSpec.BooleanValue ENABLE_PERMANENT_WATER_CULLING_TEST;
     public static final ModConfigSpec.BooleanValue ENABLE_DEEPER_OCEANS;
+    public static final ModConfigSpec.IntValue DEEPER_OCEANS_DEPTH;
+    public static final ModConfigSpec.BooleanValue WELCOME_SCREEN_SEEN;
 
     static {
         ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
@@ -58,9 +60,21 @@ public class SubmarineConfig {
                 .comment("Enable the experimental Permanent Water Culling test for submarines and boats")
                 .define("enablePermanentWaterCullingTest", false);
         ENABLE_DEEPER_OCEANS = builder
-                .comment("Deepen the ocean floor by roughly 10 blocks.",
-                        "Off = vanilla ocean depth.")
+                .comment("Deepen the ocean floor below vanilla.",
+                        "Off = vanilla ocean depth. Set the amount with deeperOceansDepth.")
                 .define("enableDeeperOceans", false);
+        DEEPER_OCEANS_DEPTH = builder
+                .comment("How many blocks deeper to push the ocean floor when enableDeeperOceans is on.",
+                        "WARNING: large values generate and render far more terrain below the sea floor",
+                        "and can badly hurt world-generation and rendering performance. Raise it carefully.")
+                .defineInRange("deeperOceansDepth", 10, 1, 256);
+        builder.pop();
+
+        builder.push("client");
+        WELCOME_SCREEN_SEEN = builder
+                .comment("Internal: set to true once the Deep Seas welcome screen has been acknowledged.",
+                        "Set back to false to show the welcome screen again on the next main menu.")
+                .define("welcomeScreenSeen", false);
         builder.pop();
 
         SPEC = builder.build();

--- a/src/main/java/com/maxenonyme/createsubmarine/worldgen/OceanDepthOffset.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/worldgen/OceanDepthOffset.java
@@ -15,7 +15,10 @@ public record OceanDepthOffset(Holder<DensityFunction> input, Holder<DensityFunc
 
     public static final KeyDispatchDataCodec<OceanDepthOffset> CODEC_HOLDER = KeyDispatchDataCodec.of(CODEC);
 
-    private static final double DEEPEN = 10.0 / 128.0;
+    private static final double DENSITY_PER_BLOCK = 1.0 / 128.0;
+    // Lower bound uses the config's maximum depth so it stays valid for any setting without
+    // reading the config during early init (which can run before configs are loaded).
+    private static final double MAX_DEEPEN = 256.0 * DENSITY_PER_BLOCK;
 
     @Override
     public double compute(FunctionContext context) {
@@ -33,7 +36,8 @@ public record OceanDepthOffset(Holder<DensityFunction> input, Holder<DensityFunc
         } else {
             return offset;
         }
-        return offset - DEEPEN * s;
+        double deepen = com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig.DEEPER_OCEANS_DEPTH.get() * DENSITY_PER_BLOCK;
+        return offset - deepen * s;
     }
 
     @Override
@@ -50,7 +54,7 @@ public record OceanDepthOffset(Holder<DensityFunction> input, Holder<DensityFunc
 
     @Override
     public double minValue() {
-        return input.value().minValue() - DEEPEN;
+        return input.value().minValue() - MAX_DEEPEN;
     }
 
     @Override

--- a/src/main/resources/assets/create_submarine/lang/en_us.json
+++ b/src/main/resources/assets/create_submarine/lang/en_us.json
@@ -76,7 +76,13 @@
   "create_submarine.configuration.enablePermanentWaterCullingTest": "Permanent Water Culling Test",
   "create_submarine.configuration.enablePermanentWaterCullingTest.tooltip": "Enable the experimental Permanent Water Culling test for submarines and boats.",
   "create_submarine.configuration.enableDeeperOceans": "Deeper Oceans",
-  "create_submarine.configuration.enableDeeperOceans.tooltip": "Deepen the ocean floor by roughly 10 blocks. Off = vanilla ocean depth.",
+  "create_submarine.configuration.enableDeeperOceans.tooltip": "Deepen the ocean floor below vanilla. Off = vanilla ocean depth. Set the amount with Deeper Oceans Depth.",
+  "create_submarine.configuration.deeperOceansDepth": "Deeper Oceans Depth",
+  "create_submarine.configuration.deeperOceansDepth.tooltip": "How many blocks deeper to push the ocean floor when Deeper Oceans is on. WARNING: large values generate and render far more terrain and can badly hurt performance. Raise it carefully. Default 10.",
+  "create_submarine.welcome.title": "Welcome to Create Deep Seas",
+  "create_submarine.welcome.message": "It's strongly recommended to set up your Deep Seas preferences before you dive in — hull strength, propulsion, ocean depth and more can all be tuned to your liking.",
+  "create_submarine.welcome.configure": "Configure the mod",
+  "create_submarine.welcome.dismiss": "Maybe later",
   "item.create_submarine.phycological_membrane": "Phycological Membrane",
   "item.create_submarine.phycological_membrane.tooltip.summary": "Can be filled with air."
 }

--- a/src/main/resources/assets/create_submarine/lang/fr_fr.json
+++ b/src/main/resources/assets/create_submarine/lang/fr_fr.json
@@ -77,7 +77,13 @@
   "create_submarine.configuration.enablePermanentWaterCullingTest": "Test d'Occlusion d'Eau",
   "create_submarine.configuration.enablePermanentWaterCullingTest.tooltip": "Active le test expérimental d'occlusion d'eau permanente pour les sous-marins et les bateaux.",
   "create_submarine.configuration.enableDeeperOceans": "Océans plus profonds",
-  "create_submarine.configuration.enableDeeperOceans.tooltip": "Approfondit le fond océanique d'environ 10 blocs. Désactivé = profondeur océanique vanilla.",
+  "create_submarine.configuration.enableDeeperOceans.tooltip": "Approfondit le fond océanique sous le niveau vanilla. Désactivé = profondeur vanilla. Règle la valeur avec Profondeur des océans.",
+  "create_submarine.configuration.deeperOceansDepth": "Profondeur des océans",
+  "create_submarine.configuration.deeperOceansDepth.tooltip": "De combien de blocs approfondir le fond océanique quand Océans plus profonds est activé. ATTENTION : de grandes valeurs génèrent et affichent beaucoup plus de terrain et peuvent gravement nuire aux performances. À augmenter prudemment. Défaut 10.",
+  "create_submarine.welcome.title": "Bienvenue dans Create Deep Seas",
+  "create_submarine.welcome.message": "Il est fortement conseillé de configurer vos préférences Deep Seas avant de plonger — solidité des coques, propulsion, profondeur des océans et plus encore se règlent à votre goût.",
+  "create_submarine.welcome.configure": "Configurer le mod",
+  "create_submarine.welcome.dismiss": "Plus tard",
   "item.create_submarine.phycological_membrane": "Membrane Phycologique",
   "item.create_submarine.phycological_membrane.tooltip.summary": "Peut être remplie d'air."
 }


### PR DESCRIPTION
Add durable per-dimension persistence and UX for physics-driven plants and ocean config. Introduces PlantPhysicsRegistry (SavedData) as the single source of truth for segment topology so lianas/attachments rebuild deterministically after reloads. Refactor SubmarineLianaBlockEntity to read topology from the registry, store transient physics joint handles, snap attachments back into place before reattaching, and avoid duplicate per-block physics that caused jitter. Update SubmarineLianaCommand to robustly assemble/tear down sublevels (helper), randomly spawn/attach fruits, persist segment metadata into the registry, and set joint/plot references on block entities. Tweak LianaLODOptimizer to wake all candidate sublevels. Add DeepSeas welcome screen, wire it into the client, and add config options: deeperOceansDepth (with warning) and a welcome-screen-seen flag. OceanDepthOffset now reads the depth config and uses a safe max bound for minValue. Add new localization strings and update changelog to describe fixes and features.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist liana chains and fruit attachments across reloads, fix physics jitter, and add a one-time Deep Seas welcome screen with configurable ocean depth.

- **Bug Fixes**
  - Lianas keep their shape after reload; joints rebuild deterministically and fruits reattach at the correct spot.
  - Removed duplicate per-block physics; only the segment’s center block drives simulation to stop jitter and collapsing.
  - `LianaLODOptimizer` now wakes all candidate sublevels so chains respond after load.

- **New Features**
  - Added per-dimension `PlantPhysicsRegistry` to persist plant segment topology (anchors, parent/child links, attachments, length).
  - `SubmarineLianaCommand` assembles/tears down chains, spawns and binds random fruits, and records segment data; block entities receive joint and plot references.
  - Added `DeepSeasWelcomeScreen`; `SubmarineConfig` adds `deeperOceansDepth` and `welcomeScreenSeen`.
  - `OceanDepthOffset` reads `deeperOceansDepth` and uses a safe max bound for `minValue`.

<sup>Written for commit 1e1dd083c35d4fed93c9c6b5f7350ae632b67564. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Maxenonyme/Create-Deep-Seas/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

