### PR TITLE
Cache ocean depth config; liana fixes

### DIFF
--- a/src/main/java/com/maxenonyme/AbyssDimension/block/entity/SubmarineLianaBlockEntity.java
+++ b/src/main/java/com/maxenonyme/AbyssDimension/block/entity/SubmarineLianaBlockEntity.java
@@ -154,7 +154,8 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
     }
 
     private ServerSubLevel findSubLevelByPlot(ServerSubLevelContainer container, int plotX, int plotZ) {
-        if (plotX == -1) return null;
+        if (plotX == -1)
+            return null;
         for (ServerSubLevel sub : container.getAllSubLevels()) {
             if (sub.getPlot() != null && sub.getPlot().plotPos.x == plotX && sub.getPlot().plotPos.z == plotZ) {
                 return sub;
@@ -191,17 +192,18 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
 
     @Override
     public void sable$physicsTick(ServerSubLevel subLevel, RigidBodyHandle handle, double timeStep) {
-        // A segment sublevel holds one liana BlockEntity per stacked block, and every one is a
-        // physics actor. Only the block at the plot centre drives the segment, otherwise each BE
-        // would recreate its own joints and stack buoyancy/player forces N times — which makes the
-        // whole chain fight itself and jitter. The non-driver BEs just render and hold light.
+        if (subLevel.getPlot() == null) {
+            return;
+        }
         if (!worldPosition.equals(subLevel.getPlot().getCenterBlock())) {
             return;
         }
 
         if (this.parentPlotX == -1 && !this.isController && this.groundAnchor == null) {
-            com.maxenonyme.AbyssDimension.system.PlantPhysicsRegistry registry = com.maxenonyme.AbyssDimension.system.PlantPhysicsRegistry.get(subLevel.getLevel());
-            com.maxenonyme.AbyssDimension.system.PlantPhysicsRegistry.SegmentData data = registry.getSegment(subLevel.getPlot().plotPos.x, subLevel.getPlot().plotPos.z);
+            com.maxenonyme.AbyssDimension.system.PlantPhysicsRegistry registry = com.maxenonyme.AbyssDimension.system.PlantPhysicsRegistry
+                    .get(subLevel.getLevel());
+            com.maxenonyme.AbyssDimension.system.PlantPhysicsRegistry.SegmentData data = registry
+                    .getSegment(subLevel.getPlot().plotPos.x, subLevel.getPlot().plotPos.z);
             if (data != null) {
                 this.isController = data.root();
                 this.segmentLen = data.segmentLen();
@@ -215,8 +217,10 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
                 this.seedPlotX = data.attachmentPlotX();
                 this.seedPlotZ = data.attachmentPlotZ();
                 if (data.hasAttachment()) {
-                    this.seedLocalAnchor = new Vector3d(data.attachmentLocalX(), data.attachmentLocalY(), data.attachmentLocalZ());
-                    this.seedOffset = new Vector3d(data.attachmentOffsetX(), data.attachmentOffsetY(), data.attachmentOffsetZ());
+                    this.seedLocalAnchor = new Vector3d(data.attachmentLocalX(), data.attachmentLocalY(),
+                            data.attachmentLocalZ());
+                    this.seedOffset = new Vector3d(data.attachmentOffsetX(), data.attachmentOffsetY(),
+                            data.attachmentOffsetZ());
                 }
             }
         }
@@ -226,11 +230,12 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
         totalForce.set(0, 0, 0);
         totalTorque.set(0, 0, 0);
 
-
         if (isController && groundAnchor != null && (groundJoint == null || !groundJoint.isValid())) {
-            ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer.getContainer(subLevel.getLevel());
+            ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer
+                    .getContainer(subLevel.getLevel());
             if (container != null) {
-                Vector3d localAnchor0 = new Vector3d(worldPosition.getX() + 0.5, worldPosition.getY(), worldPosition.getZ() + 0.5);
+                Vector3d localAnchor0 = new Vector3d(worldPosition.getX() + 0.5, worldPosition.getY(),
+                        worldPosition.getZ() + 0.5);
                 groundJoint = container.physicsSystem().getPipeline().addConstraint(
                         subLevel,
                         null,
@@ -239,9 +244,8 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
                                 new Vector3d(groundAnchor),
                                 new Quaterniond(),
                                 new Quaterniond(),
-                                EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y, ConstraintJointAxis.LINEAR_Z, ConstraintJointAxis.ANGULAR_Y)
-                        )
-                );
+                                EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y,
+                                        ConstraintJointAxis.LINEAR_Z, ConstraintJointAxis.ANGULAR_Y)));
                 if (groundJoint != null) {
                     groundJoint.setContactsEnabled(false);
                     container.physicsSystem().getPipeline().wakeUp(subLevel);
@@ -250,7 +254,8 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
         }
 
         if ((parentId != null || parentPlotX != -1) && (parentJoint == null || !parentJoint.isValid())) {
-            ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer.getContainer(subLevel.getLevel());
+            ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer
+                    .getContainer(subLevel.getLevel());
             if (container != null) {
                 ServerSubLevel parentSub = null;
                 if (parentPlotX != -1) {
@@ -262,11 +267,14 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
                 if (parentSub != null && parentSub.getPlot() != null) {
                     BlockPos parentPlotAnchor = parentSub.getPlot().getCenterBlock();
                     BlockPos currentPlotAnchor = subLevel.getPlot().getCenterBlock();
-                    dev.ryanhcode.sable.companion.math.BoundingBox3ic parentBounds = parentSub.getPlot().getBoundingBox();
+                    dev.ryanhcode.sable.companion.math.BoundingBox3ic parentBounds = parentSub.getPlot()
+                            .getBoundingBox();
                     int parentLenVal = parentBounds.maxY() - parentBounds.minY() + 1;
-                    Vector3d localAnchorCurrent = new Vector3d(parentPlotAnchor.getX() + 0.5, parentPlotAnchor.getY() + parentLenVal - 0.05, parentPlotAnchor.getZ() + 0.5);
-                    Vector3d localAnchorNext = new Vector3d(currentPlotAnchor.getX() + 0.5, currentPlotAnchor.getY() + 0.05, currentPlotAnchor.getZ() + 0.5);
-                    
+                    Vector3d localAnchorCurrent = new Vector3d(parentPlotAnchor.getX() + 0.5,
+                            parentPlotAnchor.getY() + parentLenVal - 0.05, parentPlotAnchor.getZ() + 0.5);
+                    Vector3d localAnchorNext = new Vector3d(currentPlotAnchor.getX() + 0.5,
+                            currentPlotAnchor.getY() + 0.05, currentPlotAnchor.getZ() + 0.5);
+
                     parentJoint = container.physicsSystem().getPipeline().addConstraint(
                             parentSub,
                             subLevel,
@@ -275,9 +283,8 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
                                     localAnchorNext,
                                     new Quaterniond(),
                                     new Quaterniond(),
-                                    EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y, ConstraintJointAxis.LINEAR_Z, ConstraintJointAxis.ANGULAR_Y)
-                            )
-                    );
+                                    EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y,
+                                            ConstraintJointAxis.LINEAR_Z, ConstraintJointAxis.ANGULAR_Y)));
                     if (parentJoint != null) {
                         parentJoint.setContactsEnabled(false);
                         container.physicsSystem().getPipeline().wakeUp(subLevel);
@@ -287,7 +294,6 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
             }
         }
 
-
         if ((seedId != null || seedPlotX != -1) && (seedJoint == null || !seedJoint.isValid())) {
             Vector3d localAnchorCurrent = null;
             if (seedLocalAnchor != null) {
@@ -295,15 +301,16 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
                 localAnchorCurrent = new Vector3d(
                         segmentPlotAnchor.getX() + seedLocalAnchor.x,
                         segmentPlotAnchor.getY() + seedLocalAnchor.y,
-                        segmentPlotAnchor.getZ() + seedLocalAnchor.z
-                );
+                        segmentPlotAnchor.getZ() + seedLocalAnchor.z);
             } else if (seedLocalY >= 0) {
                 BlockPos segmentPlotAnchor = subLevel.getPlot().getCenterBlock();
-                localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.9, segmentPlotAnchor.getY() + seedLocalY + 0.5, segmentPlotAnchor.getZ() + 0.5);
+                localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.9,
+                        segmentPlotAnchor.getY() + seedLocalY + 0.5, segmentPlotAnchor.getZ() + 0.5);
             }
 
             if (localAnchorCurrent != null) {
-                ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer.getContainer(subLevel.getLevel());
+                ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer
+                        .getContainer(subLevel.getLevel());
                 if (container != null) {
                     ServerSubLevel seedSub = null;
                     if (seedPlotX != -1) {
@@ -333,8 +340,9 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
                         }
 
                         BlockPos seedPlotAnchor = seedSub.getPlot().getCenterBlock();
-                        Vector3d localAnchorNext = new Vector3d(seedPlotAnchor.getX() + 0.5, seedPlotAnchor.getY() + 0.9, seedPlotAnchor.getZ() + 0.5);
-                        
+                        Vector3d localAnchorNext = new Vector3d(seedPlotAnchor.getX() + 0.5,
+                                seedPlotAnchor.getY() + 0.9, seedPlotAnchor.getZ() + 0.5);
+
                         seedJoint = container.physicsSystem().getPipeline().addConstraint(
                                 subLevel,
                                 seedSub,
@@ -343,9 +351,8 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
                                         localAnchorNext,
                                         new Quaterniond(),
                                         new Quaterniond(),
-                                        EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y, ConstraintJointAxis.LINEAR_Z)
-                                )
-                        );
+                                        EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y,
+                                                ConstraintJointAxis.LINEAR_Z)));
                         if (seedJoint != null) {
                             seedJoint.setContactsEnabled(false);
                             container.physicsSystem().getPipeline().wakeUp(subLevel);
@@ -371,11 +378,13 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
         }
 
         if (!anchored) {
-            handle.addLinearAndAngularVelocity(tempVec.set(linearVelocity).negate(), tempVec2.set(angularVelocity).negate());
+            handle.addLinearAndAngularVelocity(tempVec.set(linearVelocity).negate(),
+                    tempVec2.set(angularVelocity).negate());
             subLevel.logicalPose().position().set(restPos);
             subLevel.logicalPose().orientation().set(restRot);
             subLevel.updateLastPose();
-            ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer.getContainer(subLevel.getLevel());
+            ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer
+                    .getContainer(subLevel.getLevel());
             if (container != null) {
                 container.physicsSystem().getPipeline().teleport(subLevel, restPos, restRot);
             }
@@ -475,9 +484,12 @@ public class SubmarineLianaBlockEntity extends BlockEntity implements BlockEntit
         handle.applyForcesAndReset(forceTotal);
     }
 
-    // Topology (controller/parent/ground/attachment) is owned by PlantPhysicsRegistry, not the
-    // block entity NBT: a segment holds one BE per stacked block and the embedded-level lookup that
-    // would set those fields at spawn isn't reliable, so the NBT copy was always empty. Only the
+    // Topology (controller/parent/ground/attachment) is owned by
+    // PlantPhysicsRegistry, not the
+    // block entity NBT: a segment holds one BE per stacked block and the
+    // embedded-level lookup that
+    // would set those fields at spawn isn't reliable, so the NBT copy was always
+    // empty. Only the
     // rendered light level lives on the BE itself.
     @Override
     protected void saveAdditional(CompoundTag tag, HolderLookup.Provider registries) {

--- a/src/main/java/com/maxenonyme/AbyssDimension/system/SubmarineLianaCommand.java
+++ b/src/main/java/com/maxenonyme/AbyssDimension/system/SubmarineLianaCommand.java
@@ -90,7 +90,8 @@ public final class SubmarineLianaCommand {
         spawnCooldown = 4;
     }
 
-    private SubmarineLianaCommand() {}
+    private SubmarineLianaCommand() {
+    }
 
     public static void register(RegisterCommandsEvent event) {
         event.getDispatcher().register(
@@ -101,8 +102,7 @@ public final class SubmarineLianaCommand {
                         .then(Commands.literal("lian_radius")
                                 .then(Commands.argument("radius", IntegerArgumentType.integer(1, 50))
                                         .then(Commands.argument("length", IntegerArgumentType.integer(1, 100))
-                                                .executes(SubmarineLianaCommand::runRadius))))
-        );
+                                                .executes(SubmarineLianaCommand::runRadius)))));
     }
 
     private static int run(CommandContext<CommandSourceStack> ctx) {
@@ -177,12 +177,15 @@ public final class SubmarineLianaCommand {
         }
 
         int count = targets.size();
-        source.sendSuccess(() -> Component.literal("Queued " + count + " submarine lianas of length " + length + " to spawn progressively spreading from your position"), true);
+        source.sendSuccess(() -> Component.literal("Queued " + count + " submarine lianas of length " + length
+                + " to spawn progressively spreading from your position"), true);
         return 1;
     }
 
-    private static void rollback(ServerLevel level, java.util.Map<BlockPos, net.minecraft.world.level.block.state.BlockState> originalStates) {
-        for (java.util.Map.Entry<BlockPos, net.minecraft.world.level.block.state.BlockState> entry : originalStates.entrySet()) {
+    private static void rollback(ServerLevel level,
+            java.util.Map<BlockPos, net.minecraft.world.level.block.state.BlockState> originalStates) {
+        for (java.util.Map.Entry<BlockPos, net.minecraft.world.level.block.state.BlockState> entry : originalStates
+                .entrySet()) {
             level.setBlock(entry.getKey(), entry.getValue(), 3);
         }
     }
@@ -190,17 +193,21 @@ public final class SubmarineLianaCommand {
     private static void removeSubLevels(ServerSubLevelContainer container, List<ServerSubLevel> subLevels) {
         try {
             Class<?> reasonCls = Class.forName("dev.ryanhcode.sable.api.sublevel.SubLevelRemovalReason");
-            java.lang.reflect.Method method = ServerSubLevelContainer.class.getMethod("removeSubLevel", dev.ryanhcode.sable.sublevel.SubLevel.class, reasonCls);
+            java.lang.reflect.Method method = ServerSubLevelContainer.class.getMethod("removeSubLevel",
+                    dev.ryanhcode.sable.sublevel.SubLevel.class, reasonCls);
             Object reason = reasonCls.getEnumConstants()[0];
             for (ServerSubLevel sub : subLevels) {
                 try {
                     method.invoke(container, sub, reason);
-                } catch (Throwable ignored) {}
+                } catch (Throwable ignored) {
+                }
             }
-        } catch (Throwable ignored) {}
+        } catch (Throwable ignored) {
+        }
     }
 
-    private static List<ServerSubLevel> spawnLianaChain(ServerLevel level, ServerSubLevelContainer container, BlockPos basePos, int length) {
+    private static List<ServerSubLevel> spawnLianaChain(ServerLevel level, ServerSubLevelContainer container,
+            BlockPos basePos, int length) {
         if (level.getBlockState(basePos.above(1)).is(LianaRegistry.LIANA_BLOCK.get())) {
             return null;
         }
@@ -221,11 +228,12 @@ public final class SubmarineLianaCommand {
         Random random = new Random();
         List<Integer> seedIndices = new ArrayList<>();
         if (length > 1) {
-            int maxFruits = Math.min(2, length - 1);
+            int maxFruits = Math.min(2, numSegments);
             int fruitsToSpawn = random.nextInt(maxFruits + 1);
+            java.util.Set<Integer> usedSegments = new java.util.HashSet<>();
             while (seedIndices.size() < fruitsToSpawn) {
                 int randIdx = random.nextInt(length - 1) + 2;
-                if (!seedIndices.contains(randIdx)) {
+                if (usedSegments.add((randIdx - 1) / SEGMENT_SIZE)) {
                     seedIndices.add(randIdx);
                 }
             }
@@ -253,8 +261,7 @@ public final class SubmarineLianaCommand {
 
             BoundingBox3i bounds = new BoundingBox3i(
                     basePos.getX(), basePos.getY() + segmentStart + 1, basePos.getZ(),
-                    basePos.getX(), basePos.getY() + segmentEnd, basePos.getZ()
-            );
+                    basePos.getX(), basePos.getY() + segmentEnd, basePos.getZ());
 
             ServerSubLevel subLevel = SubLevelAssemblyHelper.assembleBlocks(level, plotAnchor, segmentBlocks, bounds);
             if (subLevel == null) {
@@ -288,29 +295,35 @@ public final class SubmarineLianaCommand {
                     if (dir == 0) {
                         seedPos = basePos.above(blockIndex).east(1);
                         seedFinalPos = new Vector3d(finalPos.x + 0.4, finalPos.y + j - 0.4, finalPos.z);
-                        localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.9, segmentPlotAnchor.getY() + j + 0.5, segmentPlotAnchor.getZ() + 0.5);
+                        localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.9,
+                                segmentPlotAnchor.getY() + j + 0.5, segmentPlotAnchor.getZ() + 0.5);
                         localAnchorOffset = new Vector3d(0.9, j + 0.5, 0.5);
                     } else if (dir == 1) {
                         seedPos = basePos.above(blockIndex).west(1);
                         seedFinalPos = new Vector3d(finalPos.x - 0.4, finalPos.y + j - 0.4, finalPos.z);
-                        localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.1, segmentPlotAnchor.getY() + j + 0.5, segmentPlotAnchor.getZ() + 0.5);
+                        localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.1,
+                                segmentPlotAnchor.getY() + j + 0.5, segmentPlotAnchor.getZ() + 0.5);
                         localAnchorOffset = new Vector3d(0.1, j + 0.5, 0.5);
                     } else if (dir == 2) {
                         seedPos = basePos.above(blockIndex).south(1);
                         seedFinalPos = new Vector3d(finalPos.x, finalPos.y + j - 0.4, finalPos.z + 0.4);
-                        localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.5, segmentPlotAnchor.getY() + j + 0.5, segmentPlotAnchor.getZ() + 0.9);
+                        localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.5,
+                                segmentPlotAnchor.getY() + j + 0.5, segmentPlotAnchor.getZ() + 0.9);
                         localAnchorOffset = new Vector3d(0.5, j + 0.5, 0.9);
                     } else {
                         seedPos = basePos.above(blockIndex).north(1);
                         seedFinalPos = new Vector3d(finalPos.x, finalPos.y + j - 0.4, finalPos.z - 0.4);
-                        localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.5, segmentPlotAnchor.getY() + j + 0.5, segmentPlotAnchor.getZ() + 0.1);
+                        localAnchorCurrent = new Vector3d(segmentPlotAnchor.getX() + 0.5,
+                                segmentPlotAnchor.getY() + j + 0.5, segmentPlotAnchor.getZ() + 0.1);
                         localAnchorOffset = new Vector3d(0.5, j + 0.5, 0.1);
                     }
 
                     originalStates.putIfAbsent(seedPos, level.getBlockState(seedPos));
                     level.setBlock(seedPos, LianaRegistry.CREEPVINE_SEED.get().defaultBlockState(), 3);
-                    BoundingBox3i seedBounds = new BoundingBox3i(seedPos.getX(), seedPos.getY(), seedPos.getZ(), seedPos.getX(), seedPos.getY(), seedPos.getZ());
-                    ServerSubLevel seedSubLevel = SubLevelAssemblyHelper.assembleBlocks(level, seedPos, List.of(seedPos), seedBounds);
+                    BoundingBox3i seedBounds = new BoundingBox3i(seedPos.getX(), seedPos.getY(), seedPos.getZ(),
+                            seedPos.getX(), seedPos.getY(), seedPos.getZ());
+                    ServerSubLevel seedSubLevel = SubLevelAssemblyHelper.assembleBlocks(level, seedPos,
+                            List.of(seedPos), seedBounds);
                     if (seedSubLevel == null) {
                         removeSubLevels(container, assembledSubLevels);
                         rollback(level, originalStates);
@@ -327,7 +340,8 @@ public final class SubmarineLianaCommand {
                     container.physicsSystem().getPipeline().teleport(seedSubLevel, seedFinalPos, new Quaterniond());
 
                     BlockPos seedPlotAnchor = seedSubLevel.getPlot().getCenterBlock();
-                    Vector3d localAnchorNext = new Vector3d(seedPlotAnchor.getX() + 0.5, seedPlotAnchor.getY() + 0.9, seedPlotAnchor.getZ() + 0.5);
+                    Vector3d localAnchorNext = new Vector3d(seedPlotAnchor.getX() + 0.5, seedPlotAnchor.getY() + 0.9,
+                            seedPlotAnchor.getZ() + 0.5);
 
                     PhysicsConstraintHandle seedJoint = container.physicsSystem().getPipeline().addConstraint(
                             subLevel,
@@ -337,14 +351,14 @@ public final class SubmarineLianaCommand {
                                     localAnchorNext,
                                     new Quaterniond(),
                                     new Quaterniond(),
-                                    EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y, ConstraintJointAxis.LINEAR_Z)
-                            )
-                    );
+                                    EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y,
+                                            ConstraintJointAxis.LINEAR_Z)));
                     if (seedJoint != null) {
                         seedJoint.setContactsEnabled(false);
                     }
 
-                    net.minecraft.world.level.block.entity.BlockEntity rawBe = subLevel.getPlot().getEmbeddedLevelAccessor().getBlockEntity(segmentPlotAnchor);
+                    net.minecraft.world.level.block.entity.BlockEntity rawBe = subLevel.getPlot()
+                            .getEmbeddedLevelAccessor().getBlockEntity(segmentPlotAnchor);
                     if (rawBe instanceof SubmarineLianaBlockEntity lianaBe) {
                         lianaBe.setSeed(seedSubLevel.getUniqueId(), localAnchorOffset);
                         lianaBe.setSeedJoint(seedJoint);
@@ -387,11 +401,11 @@ public final class SubmarineLianaCommand {
                     seedOffset != null ? seedOffset.x : 0.0,
                     seedOffset != null ? seedOffset.y : 0.0,
                     seedOffset != null ? seedOffset.z : 0.0,
-                    segmentLen
-            ));
+                    segmentLen));
 
             BlockPos plotAnchor = current.getPlot().getCenterBlock();
-            net.minecraft.world.level.block.entity.BlockEntity rawBe = current.getPlot().getEmbeddedLevelAccessor().getBlockEntity(plotAnchor);
+            net.minecraft.world.level.block.entity.BlockEntity rawBe = current.getPlot().getEmbeddedLevelAccessor()
+                    .getBlockEntity(plotAnchor);
             if (rawBe instanceof SubmarineLianaBlockEntity be) {
                 be.setController(isController);
                 be.setSegmentLen(segmentLen);
@@ -413,7 +427,8 @@ public final class SubmarineLianaCommand {
 
         if (numSegments > 0) {
             BlockPos plotAnchor0 = segments[0].getPlot().getCenterBlock();
-            Vector3d localAnchor0 = new Vector3d(plotAnchor0.getX() + 0.5, plotAnchor0.getY(), plotAnchor0.getZ() + 0.5);
+            Vector3d localAnchor0 = new Vector3d(plotAnchor0.getX() + 0.5, plotAnchor0.getY(),
+                    plotAnchor0.getZ() + 0.5);
             Vector3d worldAnchor = new Vector3d(basePos.getX() + 0.5, basePos.getY() + 1.0, basePos.getZ() + 0.5);
             PhysicsConstraintHandle groundJoint = container.physicsSystem().getPipeline().addConstraint(
                     segments[0],
@@ -423,13 +438,13 @@ public final class SubmarineLianaCommand {
                             worldAnchor,
                             new Quaterniond(),
                             new Quaterniond(),
-                            EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y, ConstraintJointAxis.LINEAR_Z, ConstraintJointAxis.ANGULAR_Y)
-                    )
-            );
+                            EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y,
+                                    ConstraintJointAxis.LINEAR_Z, ConstraintJointAxis.ANGULAR_Y)));
             if (groundJoint != null) {
                 groundJoint.setContactsEnabled(false);
             }
-            net.minecraft.world.level.block.entity.BlockEntity rawBe0 = segments[0].getPlot().getEmbeddedLevelAccessor().getBlockEntity(plotAnchor0);
+            net.minecraft.world.level.block.entity.BlockEntity rawBe0 = segments[0].getPlot().getEmbeddedLevelAccessor()
+                    .getBlockEntity(plotAnchor0);
             if (rawBe0 instanceof SubmarineLianaBlockEntity be0) {
                 be0.setGroundJoint(groundJoint);
             }
@@ -441,8 +456,10 @@ public final class SubmarineLianaCommand {
             BlockPos currentPlotAnchor = current.getPlot().getCenterBlock();
             BlockPos nextPlotAnchor = next.getPlot().getCenterBlock();
             int currentLen = Math.min(length, (i + 1) * SEGMENT_SIZE) - (i * SEGMENT_SIZE);
-            Vector3d localAnchorCurrent = new Vector3d(currentPlotAnchor.getX() + 0.5, currentPlotAnchor.getY() + currentLen - 0.05, currentPlotAnchor.getZ() + 0.5);
-            Vector3d localAnchorNext = new Vector3d(nextPlotAnchor.getX() + 0.5, nextPlotAnchor.getY() + 0.05, nextPlotAnchor.getZ() + 0.5);
+            Vector3d localAnchorCurrent = new Vector3d(currentPlotAnchor.getX() + 0.5,
+                    currentPlotAnchor.getY() + currentLen - 0.05, currentPlotAnchor.getZ() + 0.5);
+            Vector3d localAnchorNext = new Vector3d(nextPlotAnchor.getX() + 0.5, nextPlotAnchor.getY() + 0.05,
+                    nextPlotAnchor.getZ() + 0.5);
             PhysicsConstraintHandle joint = container.physicsSystem().getPipeline().addConstraint(
                     current,
                     next,
@@ -451,13 +468,13 @@ public final class SubmarineLianaCommand {
                             localAnchorNext,
                             new Quaterniond(),
                             new Quaterniond(),
-                            EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y, ConstraintJointAxis.LINEAR_Z, ConstraintJointAxis.ANGULAR_Y)
-                    )
-            );
+                            EnumSet.of(ConstraintJointAxis.LINEAR_X, ConstraintJointAxis.LINEAR_Y,
+                                    ConstraintJointAxis.LINEAR_Z, ConstraintJointAxis.ANGULAR_Y)));
             if (joint != null) {
                 joint.setContactsEnabled(false);
             }
-            net.minecraft.world.level.block.entity.BlockEntity rawBeNext = next.getPlot().getEmbeddedLevelAccessor().getBlockEntity(nextPlotAnchor);
+            net.minecraft.world.level.block.entity.BlockEntity rawBeNext = next.getPlot().getEmbeddedLevelAccessor()
+                    .getBlockEntity(nextPlotAnchor);
             if (rawBeNext instanceof SubmarineLianaBlockEntity beNext) {
                 beNext.setParentJoint(joint);
             }

--- a/src/main/java/com/maxenonyme/createsubmarine/CreateSubmarine.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/CreateSubmarine.java
@@ -230,6 +230,7 @@ public class CreateSubmarine {
                 MENUS.register(modEventBus);
                 DENSITY_FUNCTIONS.register(modEventBus);
                 modEventBus.addListener(this::onCommonSetup);
+                modEventBus.addListener(this::onConfigLoaded);
                 modEventBus.addListener(this::registerPayloads);
                 NeoForge.EVENT_BUS.addListener(SubmarinePressureSystem::onServerTick);
                 NeoForge.EVENT_BUS.addListener(SubmarineSinkingSystem::onServerTick);
@@ -325,6 +326,12 @@ public class CreateSubmarine {
                                                 return be.energyStorage;
                                         return null;
                                 });
+        }
+
+        private void onConfigLoaded(net.neoforged.fml.event.config.ModConfigEvent event) {
+                if (event.getConfig().getSpec() == SubmarineConfig.SPEC) {
+                        com.maxenonyme.createsubmarine.worldgen.OceanDepthOffset.refreshConfig();
+                }
         }
 
         private void onCommonSetup(FMLCommonSetupEvent event) {

--- a/src/main/java/com/maxenonyme/createsubmarine/worldgen/OceanDepthOffset.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/worldgen/OceanDepthOffset.java
@@ -1,5 +1,6 @@
 package com.maxenonyme.createsubmarine.worldgen;
 
+import com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.Holder;
@@ -16,14 +17,20 @@ public record OceanDepthOffset(Holder<DensityFunction> input, Holder<DensityFunc
     public static final KeyDispatchDataCodec<OceanDepthOffset> CODEC_HOLDER = KeyDispatchDataCodec.of(CODEC);
 
     private static final double DENSITY_PER_BLOCK = 1.0 / 128.0;
-    // Lower bound uses the config's maximum depth so it stays valid for any setting without
-    // reading the config during early init (which can run before configs are loaded).
     private static final double MAX_DEEPEN = 256.0 * DENSITY_PER_BLOCK;
+
+    private static volatile boolean enabled = false;
+    private static volatile double deepen = 10.0 * DENSITY_PER_BLOCK;
+
+    public static void refreshConfig() {
+        enabled = SubmarineConfig.ENABLE_DEEPER_OCEANS.get();
+        deepen = SubmarineConfig.DEEPER_OCEANS_DEPTH.get() * DENSITY_PER_BLOCK;
+    }
 
     @Override
     public double compute(FunctionContext context) {
         double offset = input.value().compute(context);
-        if (!com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig.ENABLE_DEEPER_OCEANS.get()) {
+        if (!enabled) {
             return offset;
         }
         double c = continents.value().compute(context);
@@ -36,7 +43,6 @@ public record OceanDepthOffset(Holder<DensityFunction> input, Holder<DensityFunc
         } else {
             return offset;
         }
-        double deepen = com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig.DEEPER_OCEANS_DEPTH.get() * DENSITY_PER_BLOCK;
         return offset - deepen * s;
     }
 


### PR DESCRIPTION
Add config reload hook and caching for ocean depth: OceanDepthOffset now imports SubmarineConfig, exposes refreshConfig(), and uses cached enabled/deepen values to avoid reading config during early init. Wire config reload in CreateSubmarine to call refreshConfig().

SubmarineLianaCommand: small logic and safety fixes (use numSegments when calculating potential fruit count and ensure unique segment selection), improved reflection exception handling and rollback formatting, and many whitespace/formatting cleanups across constraint setup and block assembly code.

SubmarineLianaBlockEntity: add early-return when sublevel plot is null to avoid NPEs, plus formatting/line-wrap adjustments and minor restructuring around joint creation and registry lookups. Overall this change reduces config load timing issues and tightens liana spawn/physics robustness.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache and refresh ocean-depth config to avoid early-init reads and keep worldgen consistent. Hardened liana spawn/physics and command logic to prevent NPEs and invalid constraints.

- **Bug Fixes**
  - Cached deeper-ocean settings in `OceanDepthOffset`, added `refreshConfig()`, and call it from `CreateSubmarine` on config load to sync values and avoid early-init config access.
  - `SubmarineLianaBlockEntity`: return early when the sublevel plot is null to prevent NPEs; create joints only when valid.
  - `SubmarineLianaCommand`: calculate fruit count using `numSegments` and ensure unique segment selection; safer reflection handling and cleaner rollback formatting.

<sup>Written for commit d0fe9c83bb025dd7338586b0a4ff6b2953432d2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Maxenonyme/Create-Deep-Seas/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

