### PR TITLE
Update WatermarkOverlay.java spelling issue for UI

### DIFF
--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/client/WatermarkOverlay.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/client/WatermarkOverlay.java
@@ -12,7 +12,7 @@ public class WatermarkOverlay {
             Minecraft mc = Minecraft.getInstance();
             if (mc.options.hideGui || FMLEnvironment.production) return;
             
-            String text = "[Create Deep Seas: In devloppement]";
+            String text = "[Create Deep Seas: In development]";
             int x = 10;
             int y = guiGraphics.guiHeight() - 15;
             


### PR DESCRIPTION
Fixed writing of development (originally written as « devloppement »)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the UI watermark text shown in non-production to say "In development" instead of "In devloppement". This fixes the on-screen label for testers.

<sup>Written for commit 408aeddecc7ecee912720bd3727ae0059bc23279. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Maxenonyme/Create-Deep-Seas/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

