### PR TITLE
Optimize runtime test configuration and enhance i18n support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,7 @@ dependencies {
         }
     }
     localRuntime "maven.modrinth:lithostitched:1.4.8-neoforge-1.21"
+    implementation files("libs/sable-neoforge-1.21.1-1.2.2.jar")
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/src/main/java/com/maxenonyme/AbyssDimension/system/SubmarineLianaCommand.java
+++ b/src/main/java/com/maxenonyme/AbyssDimension/system/SubmarineLianaCommand.java
@@ -109,7 +109,7 @@ public final class SubmarineLianaCommand {
         CommandSourceStack source = ctx.getSource();
         ServerPlayer player = source.getPlayer();
         if (player == null) {
-            source.sendFailure(Component.literal("Player only."));
+            source.sendFailure(Component.translatable("create_submarine.command.player_only"));
             return 0;
         }
 
@@ -117,18 +117,18 @@ public final class SubmarineLianaCommand {
         ServerLevel level = source.getLevel();
         ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer.getContainer(level);
         if (container == null) {
-            source.sendFailure(Component.literal("No sublevel container found in this dimension."));
+            source.sendFailure(Component.translatable("create_submarine.command.no_sublevel_container"));
             return 0;
         }
 
         BlockPos playerPos = player.blockPosition();
         List<ServerSubLevel> spawned = spawnLianaChain(level, container, playerPos, length);
         if (spawned == null) {
-            source.sendFailure(Component.literal("Failed to spawn submarine liana."));
+            source.sendFailure(Component.translatable("create_submarine.command.spawn_liana_failed"));
             return 0;
         }
 
-        source.sendSuccess(() -> Component.literal("Successfully spawned a submarine liana of length " + length), true);
+        source.sendSuccess(() -> Component.translatable("create_submarine.command.spawn_liana_success", length), true);
         return 1;
     }
 
@@ -136,7 +136,7 @@ public final class SubmarineLianaCommand {
         CommandSourceStack source = ctx.getSource();
         ServerPlayer player = source.getPlayer();
         if (player == null) {
-            source.sendFailure(Component.literal("Player only."));
+            source.sendFailure(Component.translatable("create_submarine.command.player_only"));
             return 0;
         }
 
@@ -145,7 +145,7 @@ public final class SubmarineLianaCommand {
         ServerLevel level = source.getLevel();
         ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer.getContainer(level);
         if (container == null) {
-            source.sendFailure(Component.literal("No sublevel container found in this dimension."));
+            source.sendFailure(Component.translatable("create_submarine.command.no_sublevel_container"));
             return 0;
         }
 
@@ -177,8 +177,7 @@ public final class SubmarineLianaCommand {
         }
 
         int count = targets.size();
-        source.sendSuccess(() -> Component.literal("Queued " + count + " submarine lianas of length " + length
-                + " to spawn progressively spreading from your position"), true);
+        source.sendSuccess(() -> Component.translatable("create_submarine.command.queue_submarine_lianas", count, length), true);
         return 1;
     }
 

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/client/HullStrengthConfigScreen.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/client/HullStrengthConfigScreen.java
@@ -34,7 +34,7 @@ public class HullStrengthConfigScreen extends Screen {
     private Button btnApply;
 
     public HullStrengthConfigScreen(ModContainer modContainer, Screen parentScreen) {
-        super(Component.literal("Hull Strength Config"));
+        super(Component.translatable("create_submarine.screen.hull_strength_config.title"));
         this.modContainer = modContainer;
         this.parentScreen = parentScreen;
         this.editedValues.putAll(HullStrengthConfig.getValues());
@@ -65,21 +65,21 @@ public class HullStrengthConfigScreen extends Screen {
         this.implosionBox.visible = false;
         this.addRenderableWidget(this.implosionBox);
 
-        this.btnApply = Button.builder(Component.literal("Apply Changes"), this::onApply)
+        this.btnApply = Button.builder(Component.translatable("create_submarine.ui.button.apply_changes"), this::onApply)
                 .bounds(rightX, 185, rightWidth, 20)
                 .build();
         this.btnApply.visible = false;
         this.addRenderableWidget(this.btnApply);
 
-        this.addRenderableWidget(Button.builder(Component.literal("Global Settings"), btn -> this.minecraft.setScreen(new ConfigurationScreen(this.modContainer, this)))
+        this.addRenderableWidget(Button.builder(Component.translatable("create_submarine.ui.button.global_settings"), btn -> this.minecraft.setScreen(new ConfigurationScreen(this.modContainer, this)))
                 .bounds(10, this.height - 30, leftWidth - 20, 20)
                 .build());
 
-        this.addRenderableWidget(Button.builder(Component.literal("Save & Exit"), btn -> this.onSave())
+        this.addRenderableWidget(Button.builder(Component.translatable("create_submarine.ui.button.save_exit"), btn -> this.onSave())
                 .bounds(this.width - 210, this.height - 30, 95, 20)
                 .build());
 
-        this.addRenderableWidget(Button.builder(Component.literal("Cancel"), btn -> this.onCancel())
+        this.addRenderableWidget(Button.builder(Component.translatable("create_submarine.ui.button.cancel"), btn -> this.onCancel())
                 .bounds(this.width - 105, this.height - 30, 95, 20)
                 .build());
 
@@ -174,7 +174,7 @@ public class HullStrengthConfigScreen extends Screen {
         g.fill(leftWidth, 30, leftWidth + 1, this.height - 40, 0x44FFFFFF);
 
         if (this.selectedBlock == null) {
-            String text = "Select a block to edit its properties";
+            String text = Component.translatable("create_submarine.ui.text.select_block_tip").getString();
             int tw = this.font.width(text);
             g.drawString(this.font, text, leftWidth + (this.width - leftWidth - tw) / 2, this.height / 2, 0x88888888, false);
         } else {
@@ -183,8 +183,8 @@ public class HullStrengthConfigScreen extends Screen {
             g.drawString(this.font, this.selectedBlock.name, rightX + 25, 44, 0xFFFFFFFF, false);
             g.drawString(this.font, Component.literal(this.selectedBlock.key), rightX, 65, 0x88888888, false);
 
-            g.drawString(this.font, Component.literal("Max Water Depth (meters)"), rightX, 85, 0xFFAAAAAA, false);
-            g.drawString(this.font, Component.literal("Implosion Chance (0.0 - 1.0)"), rightX, 135, 0xFFAAAAAA, false);
+            g.drawString(this.font, Component.translatable("create_submarine.ui.text.max_water_depth"), rightX, 85, 0xFFAAAAAA, false);
+            g.drawString(this.font, Component.translatable("create_submarine.ui.text.implosion_chance"), rightX, 135, 0xFFAAAAAA, false);
         }
     }
 

--- a/src/main/resources/assets/create_submarine/lang/en_us.json
+++ b/src/main/resources/assets/create_submarine/lang/en_us.json
@@ -84,5 +84,21 @@
   "create_submarine.welcome.configure": "Configure the mod",
   "create_submarine.welcome.dismiss": "Maybe later",
   "item.create_submarine.phycological_membrane": "Phycological Membrane",
-  "item.create_submarine.phycological_membrane.tooltip.summary": "Can be filled with air."
+  "item.create_submarine.phycological_membrane.tooltip.summary": "Can be filled with air.",
+  "create_submarine.screen.hull_strength_config.title": "Hull Strength Config",
+  "create_submarine.ui.button.apply_changes": "Apply Changes",
+  "create_submarine.ui.button.global_settings": "Global Settings",
+  "create_submarine.ui.button.save_exit": "Save & Exit",
+  "create_submarine.ui.button.cancel": "Cancel",
+  "create_submarine.ui.text.select_block_tip": "Select a block to edit its properties",
+  "create_submarine.ui.text.max_water_depth": "Max Water Depth (meters)",
+  "create_submarine.ui.text.implosion_chance": "Implosion Chance (0.0 - 1.0)",
+  "create_submarine.command.queue_submarine_lianas": "Queued %s submarine lianas of length %s to spawn progressively spreading from your position",
+  "create_submarine.command.no_sublevel_container": "No sublevel container found in this dimension.",
+  "create_submarine.command.player_only": "Player only.",
+  "create_submarine.command.spawn_liana_failed": "Failed to spawn submarine liana.",
+  "create_submarine.command.spawn_liana_success": "Successfully spawned a submarine liana of length %s",
+  "create_submarine.configuration.client": "clientSettings",
+  "create_submarine.configuration.welcomeScreenSeen": "welcomeScreenSettings",
+  "create_submarine.configuration.welcomeScreenSeen.tooltip": "Internal: set to true once the Deep Seas welcome screen has been acknowledged.Set back to false to show the welcome screen again on the next main menu."
 }

--- a/src/main/resources/assets/create_submarine/lang/en_us.json
+++ b/src/main/resources/assets/create_submarine/lang/en_us.json
@@ -100,5 +100,5 @@
   "create_submarine.command.spawn_liana_success": "Successfully spawned a submarine liana of length %s",
   "create_submarine.configuration.client": "clientSettings",
   "create_submarine.configuration.welcomeScreenSeen": "welcomeScreenSettings",
-  "create_submarine.configuration.welcomeScreenSeen.tooltip": "Internal: set to true once the Deep Seas welcome screen has been acknowledged.Set back to false to show the welcome screen again on the next main menu."
+  "create_submarine.configuration.welcomeScreenSeen.tooltip": "Internal: set to true once the Deep Seas welcome screen has been acknowledged. Set back to false to show the welcome screen again on the next main menu."
 }

--- a/src/main/resources/assets/create_submarine/lang/zh_cn.json
+++ b/src/main/resources/assets/create_submarine/lang/zh_cn.json
@@ -51,5 +51,21 @@
   "create_submarine.ponder.water_thruster.text_4": "这个水罐会为推进提供所需的水。",
 
   "block.create_submarine.glass_pressurizer": "玻璃加压器",
-  "item.create_submarine.phycological_membrane": "藻类薄膜"
+  "item.create_submarine.phycological_membrane": "藻类薄膜",
+  "create_submarine.screen.hull_strength_config.title": "船体强度配置",
+  "create_submarine.ui.button.apply_changes": "应用更改",
+  "create_submarine.ui.button.global_settings": "全局设置",
+  "create_submarine.ui.button.save_exit": "保存并退出",
+  "create_submarine.ui.button.cancel": "取消",
+  "create_submarine.ui.text.select_block_tip": "选择一个方块以编辑其属性",
+  "create_submarine.ui.text.max_water_depth": "最大水深（米）",
+  "create_submarine.ui.text.implosion_chance": "内爆概率（0.0 - 1.0）",
+  "create_submarine.command.queue_submarine_lianas": "已排队生成 %s 根长度为 %s 的潜艇藤蔓，将从你的位置开始逐步蔓延生成",
+  "create_submarine.command.no_sublevel_container": "当前维度中未找到子场景容器。",
+  "create_submarine.command.player_only": "仅玩家可执行此指令。",
+  "create_submarine.command.spawn_liana_failed": "生成潜艇藤蔓失败。",
+  "create_submarine.command.spawn_liana_success": "成功生成一根长度为 %s 的潜艇藤蔓",
+  "create_submarine.configuration.client": "客户端设置",
+  "create_submarine.configuration.welcomeScreenSeen": "欢迎屏幕设置",
+  "create_submarine.configuration.welcomeScreenSeen.tooltip": "内部：一旦深海欢迎屏幕被确认，设置为 true。设置回 false 以在下一个主菜单上再次显示欢迎屏幕。",
 }

--- a/src/main/resources/assets/create_submarine/lang/zh_cn.json
+++ b/src/main/resources/assets/create_submarine/lang/zh_cn.json
@@ -67,5 +67,5 @@
   "create_submarine.command.spawn_liana_success": "成功生成一根长度为 %s 的潜艇藤蔓",
   "create_submarine.configuration.client": "客户端设置",
   "create_submarine.configuration.welcomeScreenSeen": "欢迎屏幕设置",
-  "create_submarine.configuration.welcomeScreenSeen.tooltip": "内部：一旦深海欢迎屏幕被确认，设置为 true。设置回 false 以在下一个主菜单上再次显示欢迎屏幕。",
+  "create_submarine.configuration.welcomeScreenSeen.tooltip": "内部：一旦深海欢迎屏幕被确认，设置为 true。设置回 false 以在下一个主菜单上再次显示欢迎屏幕。"
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expanded i18n to cover command messages, the Hull Strength Config UI, and config labels/tooltips (welcome screen, client settings) in English and Chinese. Also improved local runtime by adding a required jar.

- **New Features**
  - Replaced hardcoded strings with translatable keys in Submarine Liana commands and the Hull Strength Config screen.
  - Added `en_us` and `zh_cn` strings for buttons, labels, tips, command outputs, and config keys/tooltips.

- **Dependencies**
  - Added `libs/sable-neoforge-1.21.1-1.2.2.jar` via `implementation` to stabilize the local runtime.

<sup>Written for commit 4573f28d59ddaf4dee29b9374a7cf1e8fb9c444f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Maxenonyme/Create-Deep-Seas/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

