### PR TITLE
fix: guard welcome screen against reading config before it's loaded

### DIFF
--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/client/DeepSeasWelcomeScreen.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/client/DeepSeasWelcomeScreen.java
@@ -37,12 +37,20 @@ public class DeepSeasWelcomeScreen extends Screen {
 
     /** Swap the main menu for the welcome screen the first time it opens, until acknowledged. */
     public static void onScreenOpening(ScreenEvent.Opening event) {
+        // Only act on the main menu. This also avoids reading the config during the early screens
+        // some mods open from Minecraft.<init>, before the config spec has finished loading.
+        if (!(event.getNewScreen() instanceof TitleScreen menu)) {
+            return;
+        }
+        // Guard against reading the config before it is loaded: ConfigValue.get() throws an
+        // IllegalStateException ("Cannot get config value before config is loaded") otherwise.
+        if (!SubmarineConfig.SPEC.isLoaded()) {
+            return;
+        }
         if (SubmarineConfig.WELCOME_SCREEN_SEEN.get()) {
             return;
         }
-        if (event.getNewScreen() instanceof TitleScreen menu) {
-            event.setNewScreen(new DeepSeasWelcomeScreen(menu));
-        }
+        event.setNewScreen(new DeepSeasWelcomeScreen(menu));
     }
 
     @Override


### PR DESCRIPTION
@-

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard the welcome screen hook to run only on the `TitleScreen` and to wait for config load, preventing startup crashes when early screens open. Uses `SubmarineConfig.SPEC.isLoaded()` before reading `WELCOME_SCREEN_SEEN`, then swaps in `DeepSeasWelcomeScreen` only if unseen. Fixes #19.

<sup>Written for commit 784123a98172daece718a8e3c778b0bd291d2865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Maxenonyme/Create-Deep-Seas/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

