### PR TITLE
Updated Simplified Chinese translation up to date

### DIFF
--- a/src/main/resources/assets/create_submarine/lang/zh_cn.json
+++ b/src/main/resources/assets/create_submarine/lang/zh_cn.json
@@ -113,7 +113,7 @@
 
 "create_submarine.configuration.experimental": "实验",
 "create_submarine.configuration.experimental.button": "实验",
-"create_submarine.configuration.experimental.tooltip": "实验性内容，可能导致游戏崩溃。",
+"create_submarine.configuration.experimental.tooltip": "实验性内容，可能无法正常工作。",
 
 "create_submarine.configuration.enablePermanentWaterCullingTest": "永久水体剔除测试",
 "create_submarine.configuration.enablePermanentWaterCullingTest.tooltip": "启用对潜艇和船只生效的实验性永久水体剔除测试。",

--- a/src/main/resources/assets/create_submarine/lang/zh_cn.json
+++ b/src/main/resources/assets/create_submarine/lang/zh_cn.json
@@ -1,71 +1,141 @@
 {
-  "itemGroup.create_submarine": "机械动力：潜艇",
-  "fluid.create_submarine.oxygen": "氧气",
+"itemGroup.create_submarine": "机械动力：深海",
+"fluid.create_submarine.oxygen": "氧气",
 
-  "block.create_submarine.creative_oxygenator": "创造制氧机",
-  "item.create_submarine.creative_oxygenator.tooltip.summary": "当潜艇气密时\n移除舱内积水。",
-  "item.create_submarine.creative_oxygenator.tooltip.behaviour1": "自动管理氧气\n和排水。",
+"block.create_submarine.creative_oxygenator": "创造制氧机",
+"item.create_submarine.creative_oxygenator.tooltip.summary": "当潜艇气密时\n移除舱内积水。",
+"item.create_submarine.creative_oxygenator.tooltip.behaviour1": "自动管理氧气\n和排水。",
 
-  "block.create_submarine.ballast_tank": "潜艇压载水罐",
-  "item.create_submarine.ballast_tank.tooltip.summary_part1": "使潜艇能够浮起，\n可通过",
-  "item.create_submarine.ballast_tank.tooltip.summary_part2": "注入水。",
-  "item.create_submarine.ballast_tank.tooltip.goggles": "佩戴工程师护目镜时\n可以查看容量。",
+"block.create_submarine.ballast_tank": "潜艇压载水罐",
+"item.create_submarine.ballast_tank.tooltip.summary_part1": "使潜艇能够浮起，\n可通过",
+"item.create_submarine.ballast_tank.tooltip.summary_part2": "注入水。",
+"item.create_submarine.ballast_tank.tooltip.goggles": "佩戴工程师护目镜时\n可以查看容量。",
 
-  "block.create_submarine.ballast_vent": "压载排口",
-  "block.create_submarine.oxygene_diffuser": "氧气扩散器",
-  "block.create_submarine.electrolyzer": "电解器",
+"block.create_submarine.ballast_vent": "压载排口",
+"block.create_submarine.oxygene_diffuser": "氧气扩散器",
+"block.create_submarine.electrolyzer": "电解器",
 
-  "create_submarine.simulated_section.submarine": "Deep Seas",
-  "create_submarine.gui.goggles.ballast_status": "压载水罐状态",
-  "create_submarine.gui.goggles.water": "水",
-  "create_submarine.gui.goggles.air": "空气",
-  "create_submarine.gui.goggles.connected_tanks": "已连接水罐",
+"create_submarine.simulated_section.submarine": "深海",
 
-  "create_submarine.tooltip.holdForInfo": "按住 %s 查看概要",
-  "create_submarine.tooltip.keyShift": "Shift",
+"create_submarine.gui.goggles.ballast_status": "压载水罐状态",
+"create_submarine.gui.goggles.water": "水",
+"create_submarine.gui.goggles.air": "空气",
+"create_submarine.gui.goggles.connected_tanks": "已连接水罐",
 
-  "create_submarine.ponder.ballast_vent.header": "压载排口用法",
-  "create_submarine.ponder.ballast_vent.text_1": "排口需要旋转力才能工作。",
-  "create_submarine.ponder.ballast_vent.text_2": "它必须通过管道连接到压载水罐。",
-  "create_submarine.ponder.ballast_vent.text_3": "接入动力并连接完成后，它会管理压载压力。",
-  "create_submarine.ponder.ballast_vent.text_4": "排口必须至少有一个面接触海水。",
-  "create_submarine.ponder.ballast_vent.text_5": "反转旋转方向可切换为排水模式，将水排出！",
+"create_submarine.tooltip.holdForInfo": "按住 %s 查看概要",
+"create_submarine.tooltip.keyShift": "Shift",
 
-  "block.create_submarine.industrial_alarm": "工业警报器",
+"create_submarine.ponder.ballast_vent.header": "压载排口用法",
+"create_submarine.ponder.ballast_vent.text_1": "排口需要旋转力才能工作。",
+"create_submarine.ponder.ballast_vent.text_2": "它必须通过管道连接到压载水罐。",
+"create_submarine.ponder.ballast_vent.text_3": "接入动力并连接完成后，它会管理压载压力。",
+"create_submarine.ponder.ballast_vent.text_4": "排口必须至少有一个面接触海水。",
+"create_submarine.ponder.ballast_vent.text_5": "反转旋转方向可切换为排水模式，将水排出！",
 
-  "create_submarine.ponder.oxygen_diffuser.header": "氧气扩散器用法",
-  "create_submarine.ponder.oxygen_diffuser.text_1": "氧气扩散器需要电解器生成的氧气。",
-  "create_submarine.ponder.oxygen_diffuser.text_2": "它会根据潜艇大小按比例消耗氧气。",
-  "create_submarine.ponder.oxygen_diffuser.text_3": "提供红石信号以激活氧气扩散器。",
+"block.create_submarine.industrial_alarm": "工业警报器",
 
-  "create_submarine.ponder.electrolyzer.header": "电解器用法",
-  "create_submarine.ponder.electrolyzer.text_1": "电解器需要水来生产氧气。",
-  "create_submarine.ponder.electrolyzer.text_2": "它需要 Forge 能量（FE）供能。",
-  "create_submarine.ponder.electrolyzer.text_3": "水会被转化为氧气，并输送到你的潜艇中！",
+"create_submarine.ponder.oxygen_diffuser.header": "氧气扩散器用法",
+"create_submarine.ponder.oxygen_diffuser.text_1": "氧气扩散器需要由电解器生成的氧气。",
+"create_submarine.ponder.oxygen_diffuser.text_2": "它会根据潜艇大小按比例消耗氧气。",
+"create_submarine.ponder.oxygen_diffuser.text_3": "提供红石信号以激活氧气扩散器。",
 
-  "block.create_submarine.water_thruster": "喷水推进器",
-  "create_submarine.ponder.water_thruster.header": "喷水推进器推进",
-  "create_submarine.ponder.water_thruster.text_1": "喷水推进器使用加压水流产生推力。",
-  "create_submarine.ponder.water_thruster.text_2": "将它连接到水源并提供动能即可激活。",
-  "create_submarine.ponder.water_thruster.text_3": "压力越高、转速越快，推进速度就越快！",
-  "create_submarine.ponder.water_thruster.text_4": "这个水罐会为推进提供所需的水。",
+"create_submarine.ponder.electrolyzer.header": "电解器用法",
+"create_submarine.ponder.electrolyzer.text_1": "电解器需要水来生产氧气。",
+"create_submarine.ponder.electrolyzer.text_2": "它需要 Forge 能量（FE）供能。",
+"create_submarine.ponder.electrolyzer.text_3": "水会被转化为氧气，并输送到你的潜艇中！",
+"create_submarine.ponder.electrolyzer.text_4": "你可以选用 Create Crafts & Additions、Create New Age 或 Create Power Grid 来提供电力。",
 
-  "block.create_submarine.glass_pressurizer": "玻璃加压器",
-  "item.create_submarine.phycological_membrane": "藻类薄膜",
-  "create_submarine.screen.hull_strength_config.title": "船体强度配置",
-  "create_submarine.ui.button.apply_changes": "应用更改",
-  "create_submarine.ui.button.global_settings": "全局设置",
-  "create_submarine.ui.button.save_exit": "保存并退出",
-  "create_submarine.ui.button.cancel": "取消",
-  "create_submarine.ui.text.select_block_tip": "选择一个方块以编辑其属性",
-  "create_submarine.ui.text.max_water_depth": "最大水深（米）",
-  "create_submarine.ui.text.implosion_chance": "内爆概率（0.0 - 1.0）",
-  "create_submarine.command.queue_submarine_lianas": "已排队生成 %s 根长度为 %s 的潜艇藤蔓，将从你的位置开始逐步蔓延生成",
-  "create_submarine.command.no_sublevel_container": "当前维度中未找到子场景容器。",
-  "create_submarine.command.player_only": "仅玩家可执行此指令。",
-  "create_submarine.command.spawn_liana_failed": "生成潜艇藤蔓失败。",
-  "create_submarine.command.spawn_liana_success": "成功生成一根长度为 %s 的潜艇藤蔓",
-  "create_submarine.configuration.client": "客户端设置",
-  "create_submarine.configuration.welcomeScreenSeen": "欢迎屏幕设置",
-  "create_submarine.configuration.welcomeScreenSeen.tooltip": "内部：一旦深海欢迎屏幕被确认，设置为 true。设置回 false 以在下一个主菜单上再次显示欢迎屏幕。"
+"block.create_submarine.water_thruster": "喷水推进器",
+"create_submarine.ponder.water_thruster.header": "喷水推进器推进",
+"create_submarine.ponder.water_thruster.text_1": "喷水推进器使用加压水流产生推进力。",
+"create_submarine.ponder.water_thruster.text_2": "将它连接到水源并提供动能即可激活。",
+"create_submarine.ponder.water_thruster.text_3": "压力越高、转速越快，推进速度就越快！",
+"create_submarine.ponder.water_thruster.text_4": "这个水罐会为推进提供所需的水。",
+
+"block.create_submarine.iron_pressurizer": "铁制耐压玻璃",
+"block.create_submarine.copper_pressurizer": "铜制耐压玻璃",
+"item.create_submarine.pressurizer.tooltip.summary": "使潜艇拥有\n能够抵抗水压的舷窗。",
+
+"block.create_submarine.floater": "浮力筒",
+"item.create_submarine.floater.tooltip.summary": "使船只能够浮在\n水面。",
+
+"create_submarine.ponder.poulis.header": "滑轮",
+"create_submarine.ponder.poulis.text_1": "用缆绳点击面对面的两个滑轮\n以连接到模拟装置。",
+"create_submarine.ponder.poulis.text_2": "此模拟装置随后将\n跟随缆绳移动。",
+
+"item.create_submarine.steel_cable": "钢制缆绳",
+
+"create_submarine.ponder.steel_cable.header": "钢制缆绳",
+"create_submarine.ponder.steel_cable.text_1": "实体可在绷紧的钢制缆绳上移动。",
+
+"create_submarine.ponder.steel_cable_electrified.header": "钢制缆绳——通电",
+"create_submarine.ponder.steel_cable_electrified.text_1": "使用诸如\nCreate: Addition 的电力模组，\n直接向持有缆绳的\n绳索绞盘提供 FE 以使其通电。",
+
+"create_submarine.configuration.title": "机械动力：深海",
+"create_submarine.configuration.section.create.submarine.common.toml": "通用",
+"create_submarine.configuration.section.create.submarine.common.toml.title": "通用设定",
+
+"create_submarine.configuration.gameplay": "游戏玩法",
+"create_submarine.configuration.gameplay.button": "游戏玩法",
+"create_submarine.configuration.gameplay.tooltip": "一般游戏设置。",
+
+"create_submarine.configuration.hullStrength": "船体强度",
+"create_submarine.configuration.hullStrength.button": "船体强度",
+"create_submarine.configuration.hullStrength.tooltip": "船体对于水压的抗性。",
+
+"create_submarine.configuration.propulsion": "推进力",
+"create_submarine.configuration.propulsion.button": "推进力",
+"create_submarine.configuration.propulsion.tooltip": "推进器以及压载的调节。",
+
+"create_submarine.configuration.disableImplosion": "关闭内爆伤害",
+"create_submarine.configuration.disableImplosion.tooltip": "关闭所有由水压导致的船体内爆伤害。",
+
+"create_submarine.configuration.globalMaxDepthCap": "全局最大深度上限",
+"create_submarine.configuration.globalMaxDepthCap.tooltip": "应用于所有非“机械动力：深海”方块的 maxWaterDepth 上限。各方块数值储存在 config/submarine_hull.json 中。",
+
+"create_submarine.configuration.maxDepthMultiplier": "最大深度倍率",
+"create_submarine.configuration.maxDepthMultiplier.tooltip": "运行时对所有方块有效 maxWaterDepth 的倍率。数值越低，船体越脆弱；数值越高，船体越坚固。",
+
+"create_submarine.configuration.implosionChanceMultiplier": "内爆几率倍率",
+"create_submarine.configuration.implosionChanceMultiplier.tooltip": "运行时对所有方块内爆几率的倍率。数值越低，船体开裂速度越慢；数值越高，船体开裂速度越快。",
+
+"create_submarine.configuration.ballastForceMultiplier": "压载力倍率",
+"create_submarine.configuration.ballastForceMultiplier.tooltip": "运行时对压载水罐施加垂直推力的倍率。数值越低，下潜和上浮速度越慢；数值越高，响应越灵敏。",
+
+"create_submarine.configuration.ballastTransferRateMultiplier": "压载注排速率倍率",
+"create_submarine.configuration.ballastTransferRateMultiplier.tooltip": "对压载排口注水/排水传输速率的倍率。数值越低，注水和排水速度越慢；数值越高，注水和排水速度越快。",
+
+"create_submarine.configuration.waterThrusterPowerMultiplier": "喷水推进器推力倍率",
+"create_submarine.configuration.waterThrusterPowerMultiplier.tooltip": "对喷水推进器推进力输出的倍率。数值越低，推进力越弱；数值越高，推进力越强。",
+
+"create_submarine.configuration.pulleyMaxSlideSpeed": "滑轮最大滑动速度",
+"create_submarine.configuration.pulleyMaxSlideSpeed.tooltip": "钢制缆绳上滑轮的最大滑动速度（格/秒）。超过此速度后，滑轮将开始过热。",
+
+"create_submarine.configuration.experimental": "实验",
+"create_submarine.configuration.experimental.button": "实验",
+"create_submarine.configuration.experimental.tooltip": "实验性内容，可能导致游戏崩溃。",
+
+"create_submarine.configuration.enablePermanentWaterCullingTest": "永久水体剔除测试",
+"create_submarine.configuration.enablePermanentWaterCullingTest.tooltip": "启用对潜艇和船只生效的实验性永久水体剔除测试。",
+
+"create_submarine.configuration.enableDeeperOceans": "更深的海洋",
+"create_submarine.configuration.enableDeeperOceans.tooltip": "使原版海床更深。关闭时为原版海洋深度。可在“更深的海洋深度”中调节深度。",
+
+"create_submarine.configuration.deeperOceansDepth": "更深的海洋深度",
+"create_submarine.configuration.deeperOceansDepth.tooltip": "决定当“更深的海洋”开启时，新的海床比原版深多少方块。警告：较大的值将会导致更多地形生成并渲染，可能严重影响性能。请小心设定。默认值为 10。",
+
+"create_submarine.welcome.title": "欢迎来到机械动力：深海",
+"create_submarine.welcome.message": "强烈建议您在下潜之前调整深海偏好设定——船体强度、推进力、海洋深度以及更多内容都可以根据您的喜好调整。",
+"create_submarine.welcome.configure": "设定模组",
+"create_submarine.welcome.dismiss": "之后再说",
+
+"item.create_submarine.phycological_membrane": "藻类薄膜",
+"item.create_submarine.phycological_membrane.tooltip.summary": "可充气。",
+
+"block.create_submarine.poulis": "滑轮",
+
+"entity.create_submarine.amphistium": "类比目鱼",
+"item.create_submarine.amphistium_spawn_egg": "类比目鱼刷怪蛋",
+
+"itemGroup.create_submarine.abyss_tab": "机械动力：深海"
 }

--- a/src/main/resources/assets/create_submarine/lang/zh_cn.json
+++ b/src/main/resources/assets/create_submarine/lang/zh_cn.json
@@ -94,7 +94,7 @@
 "create_submarine.configuration.globalMaxDepthCap.tooltip": "应用于所有非“机械动力：深海”方块的 maxWaterDepth 上限。各方块数值储存在 config/submarine_hull.json 中。",
 
 "create_submarine.configuration.maxDepthMultiplier": "最大深度倍率",
-"create_submarine.configuration.maxDepthMultiplier.tooltip": "运行时对所有方块有效 maxWaterDepth 的倍率。数值越低，船体越脆弱；数值越高，船体越坚固。",
+"create_submarine.configuration.maxDepthMultiplier.tooltip": "运行时对所有方块的有效 maxWaterDepth 的倍率。数值越低，船体越脆弱；数值越高，船体越坚固。",
 
 "create_submarine.configuration.implosionChanceMultiplier": "内爆几率倍率",
 "create_submarine.configuration.implosionChanceMultiplier.tooltip": "运行时对所有方块内爆几率的倍率。数值越低，船体开裂速度越慢；数值越高，船体开裂速度越快。",

--- a/src/main/resources/assets/create_submarine/lang/zh_cn.json
+++ b/src/main/resources/assets/create_submarine/lang/zh_cn.json
@@ -97,7 +97,7 @@
 "create_submarine.configuration.maxDepthMultiplier.tooltip": "运行时对所有方块的有效 maxWaterDepth 的倍率。数值越低，船体越脆弱；数值越高，船体越坚固。",
 
 "create_submarine.configuration.implosionChanceMultiplier": "内爆几率倍率",
-"create_submarine.configuration.implosionChanceMultiplier.tooltip": "运行时对所有方块内爆几率的倍率。数值越低，船体开裂速度越慢；数值越高，船体开裂速度越快。",
+"create_submarine.configuration.implosionChanceMultiplier.tooltip": "运行时对所有方块的内爆几率的倍率。数值越低，船体开裂速度越慢；数值越高，船体开裂速度越快。",
 
 "create_submarine.configuration.ballastForceMultiplier": "压载力倍率",
 "create_submarine.configuration.ballastForceMultiplier.tooltip": "运行时对压载水罐施加垂直推力的倍率。数值越低，下潜和上浮速度越慢；数值越高，响应越灵敏。",

--- a/src/main/resources/assets/create_submarine/lang/zh_cn.json
+++ b/src/main/resources/assets/create_submarine/lang/zh_cn.json
@@ -69,7 +69,7 @@
 "create_submarine.ponder.steel_cable.text_1": "实体可在绷紧的钢制缆绳上移动。",
 
 "create_submarine.ponder.steel_cable_electrified.header": "钢制缆绳——通电",
-"create_submarine.ponder.steel_cable_electrified.text_1": "使用诸如\nCreate: Addition 的电力模组，\n直接向持有缆绳的\n绳索绞盘提供 FE 以使其通电。",
+"create_submarine.ponder.steel_cable_electrified.text_1": "使用诸如\nCreate Crafts & Additions 的电力模组，\n直接向持有缆绳的\n绳索绞盘提供 FE 以使其通电。",
 
 "create_submarine.configuration.title": "机械动力：深海",
 "create_submarine.configuration.section.create.submarine.common.toml": "通用",


### PR DESCRIPTION
I don't know if merging works like this, please let me know if anything is wrong.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the Simplified Chinese localization for `create_submarine`, aligning it with current features and renaming the mod/tab to “机械动力：深海”. Adds missing strings for new blocks and entities, config screens, and Ponder content, and polishes existing wording.

- **Updates**
  - New translations for iron/copper pressurizers, floater, pulley, steel cable, Amphistium + spawn egg, and Abyss tab.
  - Full config UI labels/tooltips, incl. gameplay and experimental options (deeper oceans, water culling test), plus welcome screen text.
  - Ponder/tooltips updated, incl. electrolyzer power mods and steel cable electrification.
  - Standardized “Deep Seas” → “深海”; removed legacy “玻璃加压器” naming.

<sup>Written for commit 913610acb376816ed4d304792604ed6cd9f8ca5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Maxenonyme/Create-Deep-Seas/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

