### PR TITLE
Add mine ownership tracking and mine fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [June 6, 2026] - Cookiecutter Sharks, Naval Mines, Steel Cable Power & Propellers
+
+### New Blocks & Features
+- **Cookiecutter Shark:** Added a new deep-sea predator with its own model, swim/idle animations and a latch-and-struggle attack behavior.
+- **Underwater Mines:** Added deployable naval mines that float to hold their depth, arm when a ship or creature gets close, and detonate with a large underwater shockwave — camera shake, launched debris, and area damage.
+- **Submarine Propeller:** Added a submarine propeller block with configurable power, client-side bubble/particle wake, and dedicated rendering.
+- **Steel Cables & Electrification:** Added steel cable visuals (connector and winch variants, ponder scenes) and a cable electrification system that carries energy along cables, throws sparks, and shocks entities touching a live line.
+- **Amphistium:** Added the Amphistium, a glowing schooling fish that spawns in the Abyss biome.
+
+### Configuration & User Interface
+- **Update Notifications:** Added an in-game update checker that queries Modrinth and shows a screen when a newer Deep Seas version is available, with the changelog and an "ignore this version" option.
+- **Lithostitched Reminder:** Added a startup screen that prompts you to install the recommended Lithostitched dependency when it is missing.
+- **Item Tooltips:** Mines, propellers and floaters now show descriptive tooltips.
+
+### Bug Fixes
+- **Mines no longer detonate on their own wreckage:** Fixed mines randomly exploding while you broke blocks off them to make them resurface. Each detached chunk becomes a brand-new sublevel spawned right next to the mine, which the proximity trigger mistook for an approaching ship. Debris now inherits the mine's owner at the exact moment of the split and is ignored by the trigger, while real ships still set the mine off.
+- **Mines no longer punch holes in the ocean:** Fixed mine explosions spawning their flying-block debris in a way that silently replaced the block at the target world position, carving air pockets into the surrounding water and terrain. Debris is now thrown without ever touching the parent world.
+- **Mine depth-keeping no longer lags the server:** Replaced the once-per-second full-volume scan each mine ran (to share buoyancy between mines) with live O(1) tracking, preventing TPS drops on large hulls.
+- **Cable energy network spam:** Throttled the block-update packets sent while energy flows through cables (roughly twice a second instead of every tick) to stop network lag.
+- **Update checker visibility:** Marked the update-check result fields `volatile` so the render thread reliably sees the values fetched on the background network thread.
+- **Corrupt client state file:** Loading an empty or corrupt `create_submarine_client_state.json` no longer throws — it now falls back to defaults.
+- **Sturdier cable collisions:** Hardened cable-versus-player collision (sublevel and parent-level handling, null rope-manager guards) and made the winch energy store thread-safe.
+- **Pulley concurrency & speed:** Clamped pulley slide speed to a configurable maximum and deferred block destruction/particles to the server tick to avoid concurrency crashes.
+- **Fog submersion detection:** Reworked the underwater fog check to skip occluded positions and confirm actual water, fixing incorrect fog states.
+- **Reduced particle spam:** Lowered ballast-vent and water-thruster particle counts and frequency.
+- **Double-unregister guard:** Submarine state is now only cleared once the driver claim is actually released, preventing double-unregister glitches when several control blocks are present.
+
+### Under the Hood
+- **Submarine Driver Registry:** Added a registry that grants a single exclusive "driver" block per submarine (hull controller / oxygen diffuser) using priorities and stale-claim eviction.
+- **Mine float guard:** A mine bolted onto a contraption larger than 5 blocks no longer acts as a ballast/floater.
+- **Pressure membership helper:** Centralized the "is this position part of the ship" check (`isWithinShip`) used by the pressure system.
+- **Hull scan budgeting:** Added dynamic scan delay/budget logic to the hull controller to spread out leak scanning.
+- **Access transformer:** Added an access transformer so falling-block debris can be spawned without destructive world side effects.
+
+### Localization
+- **Translations:** Updated Simplified Chinese (`zh_cn`) and Russian (`ru_ru`) translations.
+
 ## [May 30, 2026] - Persistent Lianas, Fruit Reattachment & Configurable Oceans
 
 ### Bug Fixes

--- a/src/main/java/com/maxenonyme/AbyssDimension/client/model/CookiecutterShark.java
+++ b/src/main/java/com/maxenonyme/AbyssDimension/client/model/CookiecutterShark.java
@@ -16,11 +16,9 @@ import net.minecraft.resources.ResourceLocation;
 public class CookiecutterShark<T extends CookiecutterSharkEntity> extends HierarchicalModel<T> {
     public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(ResourceLocation.fromNamespaceAndPath(CreateSubmarine.MOD_ID, "cookiecutter_shark"), "main");
     private final ModelPart root;
-    private final ModelPart bone2;
 
     public CookiecutterShark(ModelPart root) {
         this.root = root;
-        this.bone2 = root.getChild("bone2");
     }
 
     public static LayerDefinition createBodyLayer() {

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/UnderwaterMineBlockEntity.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/UnderwaterMineBlockEntity.java
@@ -1,6 +1,7 @@
 package com.maxenonyme.createsubmarine.submarine.block.entity;
 
 import com.maxenonyme.createsubmarine.CreateSubmarine;
+import com.maxenonyme.createsubmarine.submarine.system.MineOwnershipRegistry;
 import com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper;
 import com.maxenonyme.createsubmarine.submarine.util.SubLevelRegistry;
 import dev.ryanhcode.sable.companion.SableCompanion;
@@ -13,6 +14,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import net.minecraft.server.level.ServerLevel;
@@ -33,10 +35,10 @@ import dev.ryanhcode.sable.companion.math.BoundingBox3ic;
 public class UnderwaterMineBlockEntity extends BlockEntity {
     private static final int MAX_WATER_SCAN = 200;
 
-    private static final Map<UUID, Integer> MINE_COUNTS = new ConcurrentHashMap<>();
-    private static final Map<UUID, Long> LAST_COUNT_TIMES = new ConcurrentHashMap<>();
+    private static final Map<UUID, Set<BlockPos>> ACTIVE_MINES = new ConcurrentHashMap<>();
     private boolean isExploded = false;
     public UUID ownerUUID;
+    private UUID trackedSubId;
 
     public UnderwaterMineBlockEntity(BlockPos pos, BlockState state) {
         super(CreateSubmarine.UNDERWATER_MINE_BE.get(), pos, state);
@@ -59,36 +61,52 @@ public class UnderwaterMineBlockEntity extends BlockEntity {
     }
 
     public static void clearAll() {
-        MINE_COUNTS.clear();
-        LAST_COUNT_TIMES.clear();
+        ACTIVE_MINES.clear();
+        MineOwnershipRegistry.clearAll();
     }
 
-    private static int getMineCount(Level level, SubLevelAccess sub) {
-        UUID id = sub.getUniqueId();
-        long time = level.getGameTime();
-        Long lastTime = LAST_COUNT_TIMES.get(id);
-        if (lastTime != null && time - lastTime < 20) {
-            return MINE_COUNTS.getOrDefault(id, 1);
+    @Override
+    public void setRemoved() {
+        super.setRemoved();
+        if (trackedSubId != null) {
+            Set<BlockPos> mines = ACTIVE_MINES.get(trackedSubId);
+            if (mines != null) {
+                mines.remove(worldPosition);
+                if (mines.isEmpty()) {
+                    ACTIVE_MINES.remove(trackedSubId);
+                }
+            }
+            trackedSubId = null;
         }
-        SubLevelRegistry.PlotBounds bounds = SubLevelRegistry.getBounds(id);
+    }
+
+    private static int getMineCount(UUID subId) {
+        Set<BlockPos> mines = ACTIVE_MINES.get(subId);
+        int count = (mines != null) ? mines.size() : 0;
+        return count == 0 ? 1 : count;
+    }
+
+    private static boolean exceedsFloatBlockLimit(Level level, SubLevelAccess sub) {
+        if (!(sub instanceof SubLevel sl) || sl.getPlot() == null) {
+            return false;
+        }
+        BoundingBox3ic bounds = sl.getPlot().getBoundingBox();
+        if (bounds == null) {
+            return false;
+        }
         int count = 0;
-        if (bounds != null && !bounds.isEmpty()) {
-            BlockPos.MutableBlockPos p = new BlockPos.MutableBlockPos();
-            for (int x = bounds.minX(); x <= bounds.maxX(); x++) {
-                for (int y = bounds.minY(); y <= bounds.maxY(); y++) {
-                    for (int z = bounds.minZ(); z <= bounds.maxZ(); z++) {
-                        p.set(x, y, z);
-                        if (level.getBlockState(p).is(CreateSubmarine.UNDERWATER_MINE.get())) {
-                            count++;
-                        }
+        BlockPos.MutableBlockPos p = new BlockPos.MutableBlockPos();
+        for (int x = bounds.minX(); x <= bounds.maxX(); x++) {
+            for (int y = bounds.minY(); y <= bounds.maxY(); y++) {
+                for (int z = bounds.minZ(); z <= bounds.maxZ(); z++) {
+                    p.set(x, y, z);
+                    if (!level.getBlockState(p).isAir() && ++count > 5) {
+                        return true;
                     }
                 }
             }
         }
-        if (count == 0) count = 1;
-        MINE_COUNTS.put(id, count);
-        LAST_COUNT_TIMES.put(id, time);
-        return count;
+        return false;
     }
 
     public static void serverTick(Level level, BlockPos pos, UnderwaterMineBlockEntity be) {
@@ -97,6 +115,11 @@ public class UnderwaterMineBlockEntity extends BlockEntity {
         SubLevelAccess sub = SableCompanion.INSTANCE.getContaining(level, pos);
         if (sub == null)
             return;
+
+        UUID subId = sub.getUniqueId();
+        ACTIVE_MINES.computeIfAbsent(subId, k -> ConcurrentHashMap.newKeySet()).add(pos);
+        be.trackedSubId = subId;
+        MineOwnershipRegistry.tag(subId, be.ownerUUID);
 
         Vector3d worldPos = new Vector3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
         sub.logicalPose().transformPosition(worldPos);
@@ -136,6 +159,9 @@ public class UnderwaterMineBlockEntity extends BlockEntity {
                     if (sub != null && otherSubId.equals(sub.getUniqueId())) {
                         continue;
                     }
+                    if (be.ownerUUID != null && be.ownerUUID.equals(MineOwnershipRegistry.getOwner(otherSubId))) {
+                        continue;
+                    }
                     Vector3d localInOther = new Vector3d(worldPos.x, worldPos.y, worldPos.z);
                     otherSub.logicalPose().transformPositionInverse(localInOther);
 
@@ -161,6 +187,10 @@ public class UnderwaterMineBlockEntity extends BlockEntity {
 
         if (sub == null)
             return;
+
+        if (exceedsFloatBlockLimit(level, sub)) {
+            return;
+        }
 
         Object handle = SablePhysicsHelper.getHandle(sub);
         Vector3dc currentVel = SablePhysicsHelper.getVelocity(handle);
@@ -198,7 +228,7 @@ public class UnderwaterMineBlockEntity extends BlockEntity {
         double mass = SablePhysicsHelper.readMass(sub);
 
         double forceMult = com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig.BALLAST_FORCE_MULTIPLIER.get();
-        int count = getMineCount(level, sub);
+        int count = getMineCount(subId);
         double forceToApply = ((errorY * mass * 0.8 * forceMult) * submergedRatio) / count;
 
         double ballastMaxForce = (16000.0 * mass * forceMult) / count;
@@ -370,34 +400,29 @@ public class UnderwaterMineBlockEntity extends BlockEntity {
         }
 
         if (spawnEntity) {
-            FallingBlockEntity fallingBlock = FallingBlockEntity.fall(
-                    parentLevel,
-                    BlockPos.containing(worldBlockPos.x, worldBlockPos.y, worldBlockPos.z),
-                    state);
+            FallingBlockEntity fallingBlock = new FallingBlockEntity(
+                    parentLevel, worldBlockPos.x, worldBlockPos.y, worldBlockPos.z, state);
+            fallingBlock.time = 1;
+            fallingBlock.dropItem = false;
 
-            if (fallingBlock != null) {
-                fallingBlock.moveTo(worldBlockPos.x, worldBlockPos.y, worldBlockPos.z, 0, 0);
-                fallingBlock.time = 1;
-                fallingBlock.dropItem = false;
-
-                Vector3d direction = new Vector3d(worldBlockPos).sub(explosionSource);
-                double dist = direction.length();
-                if (dist < 0.1) {
-                    direction.set(0, 1, 0);
-                    dist = 1.0;
-                } else {
-                    direction.normalize();
-                }
-
-                double force = 1.5 * (1.0 - (dist / 8.0));
-                double vx = direction.x * force + (parentLevel.random.nextFloat() - 0.5f) * 0.3;
-                double vy = Math.abs(direction.y * force) + 0.6 + parentLevel.random.nextFloat() * 0.4;
-                double vz = direction.z * force + (parentLevel.random.nextFloat() - 0.5f) * 0.3;
-
-                fallingBlock.setDeltaMovement(new net.minecraft.world.phys.Vec3(vx, vy, vz));
-                fallingBlock.hurtMarked = true;
-                return true;
+            Vector3d direction = new Vector3d(worldBlockPos).sub(explosionSource);
+            double dist = direction.length();
+            if (dist < 0.1) {
+                direction.set(0, 1, 0);
+                dist = 1.0;
+            } else {
+                direction.normalize();
             }
+
+            double force = 1.5 * (1.0 - (dist / 8.0));
+            double vx = direction.x * force + (parentLevel.random.nextFloat() - 0.5f) * 0.3;
+            double vy = Math.abs(direction.y * force) + 0.6 + parentLevel.random.nextFloat() * 0.4;
+            double vz = direction.z * force + (parentLevel.random.nextFloat() - 0.5f) * 0.3;
+
+            fallingBlock.setDeltaMovement(new net.minecraft.world.phys.Vec3(vx, vy, vz));
+            fallingBlock.hurtMarked = true;
+            parentLevel.addFreshEntity(fallingBlock);
+            return true;
         }
         return false;
     }

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/config/SubmarineClientState.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/config/SubmarineClientState.java
@@ -21,14 +21,16 @@ public class SubmarineClientState {
         if (Files.exists(PATH)) {
             try {
                 JsonObject json = GSON.fromJson(Files.readString(PATH), JsonObject.class);
-                if (json.has("welcomeScreenSeen")) {
-                    welcomeScreenSeen = json.get("welcomeScreenSeen").getAsBoolean();
-                }
-                if (json.has("lithostitchedScreenSeen")) {
-                    lithostitchedScreenSeen = json.get("lithostitchedScreenSeen").getAsBoolean();
-                }
-                if (json.has("ignoredUpdateVersion")) {
-                    ignoredUpdateVersion = json.get("ignoredUpdateVersion").getAsString();
+                if (json != null) {
+                    if (json.has("welcomeScreenSeen")) {
+                        welcomeScreenSeen = json.get("welcomeScreenSeen").getAsBoolean();
+                    }
+                    if (json.has("lithostitchedScreenSeen")) {
+                        lithostitchedScreenSeen = json.get("lithostitchedScreenSeen").getAsBoolean();
+                    }
+                    if (json.has("ignoredUpdateVersion")) {
+                        ignoredUpdateVersion = json.get("ignoredUpdateVersion").getAsString();
+                    }
                 }
             } catch (Exception e) {
                 CreateSubmarine.LOGGER.error("[CDS] Failed to load create_submarine_client_state.json", e);

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/mixin/compat/sable/ServerSubLevelMixin.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/mixin/compat/sable/ServerSubLevelMixin.java
@@ -1,0 +1,18 @@
+package com.maxenonyme.createsubmarine.submarine.mixin.compat.sable;
+
+import com.maxenonyme.createsubmarine.submarine.system.MineOwnershipRegistry;
+import dev.ryanhcode.sable.companion.math.Pose3d;
+import dev.ryanhcode.sable.sublevel.ServerSubLevel;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerSubLevel.class)
+public class ServerSubLevelMixin {
+
+    @Inject(method = "setSplitFrom", at = @At("HEAD"))
+    private void createsubmarine$inheritMineOwnership(ServerSubLevel containingSubLevel, Pose3d originalPose, CallbackInfo ci) {
+        MineOwnershipRegistry.onSplit(((ServerSubLevel) (Object) this).getUniqueId(), containingSubLevel.getUniqueId());
+    }
+}

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/system/CableElectrificationSystem.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/system/CableElectrificationSystem.java
@@ -190,12 +190,13 @@ public class CableElectrificationSystem {
                         adjStorage.receiveEnergy(actualExtracted, false);
                         if (actualExtracted > 0) {
                             be.setChanged();
-                            if (level instanceof ServerLevel sl) {
+                            boolean sync = tickCounter % 10 == 0;
+                            if (sync && level instanceof ServerLevel sl) {
                                 sl.sendBlockUpdated(pos, be.getBlockState(), be.getBlockState(), 2);
                             }
                             if (adjBE instanceof RopeWinchBlockEntity || adjBE instanceof RopeConnectorBlockEntity) {
                                 adjBE.setChanged();
-                                if (level instanceof ServerLevel sl) {
+                                if (sync && level instanceof ServerLevel sl) {
                                     sl.sendBlockUpdated(adjPos, adjBE.getBlockState(), adjBE.getBlockState(), 2);
                                 }
                             }
@@ -212,12 +213,13 @@ public class CableElectrificationSystem {
                         myStorage.receiveEnergy(actualExtracted, false);
                         if (actualExtracted > 0) {
                             be.setChanged();
-                            if (level instanceof ServerLevel sl) {
+                            boolean sync = tickCounter % 10 == 0;
+                            if (sync && level instanceof ServerLevel sl) {
                                 sl.sendBlockUpdated(pos, be.getBlockState(), be.getBlockState(), 2);
                             }
                             if (adjBE instanceof RopeWinchBlockEntity || adjBE instanceof RopeConnectorBlockEntity) {
                                 adjBE.setChanged();
-                                if (level instanceof ServerLevel sl) {
+                                if (sync && level instanceof ServerLevel sl) {
                                     sl.sendBlockUpdated(adjPos, adjBE.getBlockState(), adjBE.getBlockState(), 2);
                                 }
                             }

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/system/MineOwnershipRegistry.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/system/MineOwnershipRegistry.java
@@ -1,0 +1,33 @@
+package com.maxenonyme.createsubmarine.submarine.system;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class MineOwnershipRegistry {
+    private static final Map<UUID, UUID> OWNERS = new ConcurrentHashMap<>();
+
+    private MineOwnershipRegistry() {
+    }
+
+    public static void tag(UUID subLevelId, UUID owner) {
+        if (subLevelId != null && owner != null) {
+            OWNERS.put(subLevelId, owner);
+        }
+    }
+
+    public static UUID getOwner(UUID subLevelId) {
+        return OWNERS.get(subLevelId);
+    }
+
+    public static void onSplit(UUID newSubLevelId, UUID parentSubLevelId) {
+        UUID owner = OWNERS.get(parentSubLevelId);
+        if (owner != null) {
+            OWNERS.put(newSubLevelId, owner);
+        }
+    }
+
+    public static void clearAll() {
+        OWNERS.clear();
+    }
+}

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/system/UpdateChecker.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/system/UpdateChecker.java
@@ -16,9 +16,9 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 
 public final class UpdateChecker {
-    private static boolean updateAvailable = false;
-    private static String latestVersion = null;
-    private static String latestChangelog = null;
+    private static volatile boolean updateAvailable = false;
+    private static volatile String latestVersion = null;
+    private static volatile String latestChangelog = null;
 
     public static void check() {
         if (!FMLEnvironment.dist.isClient()) {

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,1 @@
+public net.minecraft.world.entity.item.FallingBlockEntity <init>(Lnet/minecraft/world/level/Level;DDDLnet/minecraft/world/level/block/state/BlockState;)V

--- a/src/main/resources/create_submarine.mixins.json
+++ b/src/main/resources/create_submarine.mixins.json
@@ -13,7 +13,8 @@
     "RopeConnectorBlockEntityMixin",
     "SmartBlockEntityMixin",
     "EntityWaterPhysicsMixin",
-    "compat.SablePhysicsCrashFixMixin"
+    "compat.SablePhysicsCrashFixMixin",
+    "compat.sable.ServerSubLevelMixin"
   ],
   "client": [
     "ClientRopeStrandMixin",


### PR DESCRIPTION
Introduce MineOwnershipRegistry and per-sublevel ACTIVE_MINES tracking to correctly tag/de-duplicate mines and inherit ownership on sublevel splits (via a new ServerSubLevelMixin). Fix mine debris spawning by constructing FallingBlockEntity directly and adding an access transformer for the constructor to avoid destructive world-side effects. Prevent mines from acting as float ballast on large contraptions, avoid self-detonation on spawned wreckage, and optimize mine counting/tracking. Also: throttle network block-update syncs for cable electrification, make UpdateChecker fields volatile, harden client state loading against null/corrupt files, remove an unused model part in CookiecutterShark, and update mixins and changelog to reflect these changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds mine ownership tracking and per-sublevel active-mine counting to stop self-detonation and duplicate buoyancy, and fixes debris spawning so explosions don’t replace world blocks. Also improves cable sync performance and hardens client state loading.

- **Bug Fixes**
  - Mines no longer detonate on their own wreckage; ownership is inherited on sublevel splits and same-owner/same-sub triggers are ignored.
  - Mine debris now spawns via direct `FallingBlockEntity` construction, preventing accidental world block replacement.
  - Mines bolted to large contraptions no longer act as float ballast.
  - Client state load no longer fails on null/corrupt `create_submarine_client_state.json`.

- **Refactors**
  - Added `MineOwnershipRegistry` and per-sublevel `ACTIVE_MINES` for O(1) mine tracking; new `ServerSubLevelMixin` copies ownership on splits.
  - Throttled cable electrification block-update syncs to every 10 ticks.
  - Made `UpdateChecker` fields `volatile` for cross-thread visibility.
  - Removed an unused `CookiecutterShark` model part.

<sup>Written for commit 5f8dcb91c25513d49fbcd580fa99ac5b53ff1eca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Maxenonyme/Create-Deep-Seas/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

