### PR TITLE
Level-aware compartment lookup; cache inside check

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ loader_version_range=[1,)
 mod_id=create_submarine
 mod_name=Create Deep Seas
 mod_license=All Rights Reserved
-mod_version=2.1.4
+mod_version=2.1.5
 mod_group_id=com.maxenonyme.createsubmarine
 
 

--- a/src/main/java/com/maxenonyme/createsubmarine/TestEntityMethods.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/TestEntityMethods.java
@@ -1,9 +1,0 @@
-public class TestEntityMethods {
-    public static void main(String[] args) throws Exception {
-        for (java.lang.reflect.Method m : net.minecraft.world.entity.Entity.class.getDeclaredMethods()) {
-            if (m.getName().toLowerCase().contains("fluid") || m.getName().toLowerCase().contains("water") || m.getName().toLowerCase().contains("eye")) {
-                System.out.println(m.getReturnType().getSimpleName() + " " + m.getName() + "(...)");
-            }
-        }
-    }
-}

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/compartment/CompartmentTracker.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/compartment/CompartmentTracker.java
@@ -216,7 +216,7 @@ public class CompartmentTracker {
     }
 
     public static boolean isOccluded(Level level, BlockPos worldPos) {
-        return findContainingSub(worldPos, VISUAL_UNION) != null;
+        return findContainingSub(level, worldPos, VISUAL_UNION) != null;
     }
 
     public static boolean isInSealed(Level level, BlockPos worldPos) {
@@ -225,25 +225,27 @@ public class CompartmentTracker {
 
     @Nullable
     public static UUID findSealedSublevel(Level level, BlockPos worldPos) {
-        return findContainingSub(worldPos, SEALED_UNION);
+        return findContainingSub(level, worldPos, SEALED_UNION);
     }
 
     public static boolean isOccludedExact(Level level, net.minecraft.world.phys.Vec3 exactPos) {
-        return findContainingSubExact(exactPos, VISUAL_UNION) != null;
+        return findContainingSubExact(level, exactPos, VISUAL_UNION) != null;
     }
 
     public static boolean isInSealedExact(Level level, net.minecraft.world.phys.Vec3 exactPos) {
-        return findContainingSubExact(exactPos, SEALED_UNION) != null;
+        return findContainingSubExact(level, exactPos, SEALED_UNION) != null;
     }
 
     @Nullable
-    private static UUID findContainingSubExact(net.minecraft.world.phys.Vec3 exactPos, Map<UUID, Set<BlockPos>> blockSetPerSub) {
+    private static UUID findContainingSubExact(Level level, net.minecraft.world.phys.Vec3 exactPos, Map<UUID, Set<BlockPos>> blockSetPerSub) {
         AABB gb = globalBounds;
         if (gb == null) return null;
         if (!gb.contains(exactPos.x, exactPos.y, exactPos.z)) return null;
 
         for (Map.Entry<UUID, SubLevelAccess> e : SUBS.entrySet()) {
             UUID id = e.getKey();
+            SubLevelAccess access = e.getValue();
+            if (access instanceof dev.ryanhcode.sable.sublevel.SubLevel sl && sl.getLevel() != level) continue;
             AABB aabb = WORLD_AABB.get(id);
             if (aabb == null || !aabb.contains(exactPos.x, exactPos.y, exactPos.z)) continue;
             Set<BlockPos> blocks = blockSetPerSub.get(id);
@@ -251,7 +253,7 @@ public class CompartmentTracker {
 
             Vector3d local = new Vector3d(exactPos.x, exactPos.y, exactPos.z);
             try {
-                e.getValue().logicalPose().transformPositionInverse(local);
+                access.logicalPose().transformPositionInverse(local);
             } catch (Exception ex) {
                 continue;
             }
@@ -261,7 +263,7 @@ public class CompartmentTracker {
     }
 
     @Nullable
-    private static UUID findContainingSub(BlockPos worldPos, Map<UUID, Set<BlockPos>> blockSetPerSub) {
+    private static UUID findContainingSub(Level level, BlockPos worldPos, Map<UUID, Set<BlockPos>> blockSetPerSub) {
         AABB gb = globalBounds;
         if (gb == null) return null;
         double cx = worldPos.getX() + 0.5, cy = worldPos.getY() + 0.5, cz = worldPos.getZ() + 0.5;
@@ -269,6 +271,8 @@ public class CompartmentTracker {
 
         for (Map.Entry<UUID, SubLevelAccess> e : SUBS.entrySet()) {
             UUID id = e.getKey();
+            SubLevelAccess access = e.getValue();
+            if (access instanceof dev.ryanhcode.sable.sublevel.SubLevel sl && sl.getLevel() != level) continue;
             AABB aabb = WORLD_AABB.get(id);
             if (aabb == null || !aabb.contains(cx, cy, cz)) continue;
             Set<BlockPos> blocks = blockSetPerSub.get(id);
@@ -276,7 +280,7 @@ public class CompartmentTracker {
 
             Vector3d local = new Vector3d(cx, cy, cz);
             try {
-                e.getValue().logicalPose().transformPositionInverse(local);
+                access.logicalPose().transformPositionInverse(local);
             } catch (Exception ex) {
                 continue;
             }

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/mixin/EntityWaterPhysicsMixin.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/mixin/EntityWaterPhysicsMixin.java
@@ -57,6 +57,8 @@ public abstract class EntityWaterPhysicsMixin {
     @Unique
     private long createsubmarine$cacheTick = -1L;
     @Unique
+    private double createsubmarine$cacheX, createsubmarine$cacheY, createsubmarine$cacheZ, createsubmarine$cacheEyeY;
+    @Unique
     private boolean createsubmarine$cachedInside = false;
 
     @Unique
@@ -65,9 +67,14 @@ public abstract class EntityWaterPhysicsMixin {
         if (entity.level() == null) return false;
 
         long tick = entity.level().getGameTime();
-        if (tick == createsubmarine$cacheTick) return createsubmarine$cachedInside;
+        double x = entity.getX(), y = entity.getY(), z = entity.getZ(), eyeY = entity.getEyeY();
+        if (tick == createsubmarine$cacheTick
+                && x == createsubmarine$cacheX && y == createsubmarine$cacheY
+                && z == createsubmarine$cacheZ && eyeY == createsubmarine$cacheEyeY) {
+            return createsubmarine$cachedInside;
+        }
 
-        net.minecraft.world.phys.Vec3 eyePos = new net.minecraft.world.phys.Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
+        net.minecraft.world.phys.Vec3 eyePos = new net.minecraft.world.phys.Vec3(x, eyeY, z);
         boolean inside = com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.isOccludedExact(entity.level(), eyePos);
         if (!inside) {
             net.minecraft.world.phys.Vec3 feetPos = entity.position();
@@ -75,6 +82,10 @@ public abstract class EntityWaterPhysicsMixin {
         }
 
         createsubmarine$cacheTick = tick;
+        createsubmarine$cacheX = x;
+        createsubmarine$cacheY = y;
+        createsubmarine$cacheZ = z;
+        createsubmarine$cacheEyeY = eyeY;
         createsubmarine$cachedInside = inside;
         return inside;
     }

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/mixin/EntityWaterPhysicsMixin.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/mixin/EntityWaterPhysicsMixin.java
@@ -55,14 +55,27 @@ public abstract class EntityWaterPhysicsMixin {
     }
 
     @Unique
+    private long createsubmarine$cacheTick = -1L;
+    @Unique
+    private boolean createsubmarine$cachedInside = false;
+
+    @Unique
     private boolean createsubmarine$isInsideAirtightSub() {
         Entity entity = (Entity) (Object) this;
         if (entity.level() == null) return false;
-        
+
+        long tick = entity.level().getGameTime();
+        if (tick == createsubmarine$cacheTick) return createsubmarine$cachedInside;
+
         net.minecraft.world.phys.Vec3 eyePos = new net.minecraft.world.phys.Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
-        if (com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.isOccludedExact(entity.level(), eyePos)) return true;
-        
-        net.minecraft.world.phys.Vec3 feetPos = entity.position();
-        return com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.isOccludedExact(entity.level(), feetPos);
+        boolean inside = com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.isOccludedExact(entity.level(), eyePos);
+        if (!inside) {
+            net.minecraft.world.phys.Vec3 feetPos = entity.position();
+            inside = com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.isOccludedExact(entity.level(), feetPos);
+        }
+
+        createsubmarine$cacheTick = tick;
+        createsubmarine$cachedInside = inside;
+        return inside;
     }
 }


### PR DESCRIPTION
Bump mod version to 2.1.5 and remove a temporary TestEntityMethods utility. Update CompartmentTracker to make findContainingSub and findContainingSubExact level-aware (add Level parameter) and skip SubLevel entries that belong to a different level. Use a local SubLevelAccess variable consistently when transforming positions. In EntityWaterPhysicsMixin add per-tick caching (createsubmarine$cacheTick / createsubmarine$cachedInside) for the airtight-inside check to avoid redundant compartment lookups within the same game tick.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make compartment lookups level-aware and add a per‑tick, position‑aware cache for the airtight check to prevent cross‑level false positives and redundant scans. Bumps mod to 2.1.5.

- **Bug Fixes**
  - `CompartmentTracker`: add `Level` to `findContainingSub` and `findContainingSubExact`; skip `SubLevel` entries from other levels.
  - Use a local `SubLevelAccess` when transforming positions for consistent results.
  - `EntityWaterPhysicsMixin`: per‑tick, position‑aware cache (`createsubmarine$cacheTick`, `createsubmarine$cacheX/Y/Z`, `createsubmarine$cacheEyeY`, `createsubmarine$cachedInside`) for eye/feet airtight checks to avoid repeated lookups and stale results.

- **Refactors**
  - Remove temporary `TestEntityMethods` utility.

<sup>Written for commit 726e21da60cc05b84f07ea2495f78e2d6eef2776. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Maxenonyme/Create-Deep-Seas/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

