### PR TITLE
Cache rope reflection; fix compartment & barometer

### DIFF
--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/block/SteelCableItem.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/block/SteelCableItem.java
@@ -17,6 +17,31 @@ import net.minecraft.world.level.Level;
 
 public class SteelCableItem extends RopeItem {
 
+    private static java.lang.reflect.Method createRopeMethod = null;
+    private static boolean createRopeMethodNeedsBool = true;
+    private static boolean createRopeMethodFailed = false;
+
+    private static java.lang.reflect.Method getCreateRopeMethod() {
+        if (createRopeMethodFailed) return null;
+        if (createRopeMethod != null) return createRopeMethod;
+        try {
+            createRopeMethod = dev.simulated_team.simulated.content.blocks.rope.RopeStrandHolderBehavior.class.getMethod("createRope", dev.simulated_team.simulated.content.blocks.rope.RopeStrandHolderBehavior.class, boolean.class);
+            createRopeMethodNeedsBool = true;
+        } catch (NoSuchMethodException e) {
+            try {
+                createRopeMethod = dev.simulated_team.simulated.content.blocks.rope.RopeStrandHolderBehavior.class.getMethod("createRope", dev.simulated_team.simulated.content.blocks.rope.RopeStrandHolderBehavior.class);
+                createRopeMethodNeedsBool = false;
+            } catch (Exception ex) {
+                createRopeMethodFailed = true;
+                ex.printStackTrace();
+            }
+        } catch (Exception e) {
+            createRopeMethodFailed = true;
+            e.printStackTrace();
+        }
+        return createRopeMethod;
+    }
+
     public SteelCableItem(Properties properties) {
         super(properties);
     }
@@ -83,14 +108,13 @@ public class SteelCableItem extends RopeItem {
 
         boolean success = false;
         try {
-            java.lang.reflect.Method createRopeMethod = dev.simulated_team.simulated.content.blocks.rope.RopeStrandHolderBehavior.class.getMethod("createRope", dev.simulated_team.simulated.content.blocks.rope.RopeStrandHolderBehavior.class, boolean.class);
-            success = (boolean) createRopeMethod.invoke(ropeHolderA, ropeHolderB, false);
-        } catch (NoSuchMethodException e) {
-            try {
-                java.lang.reflect.Method createRopeMethod = dev.simulated_team.simulated.content.blocks.rope.RopeStrandHolderBehavior.class.getMethod("createRope", dev.simulated_team.simulated.content.blocks.rope.RopeStrandHolderBehavior.class);
-                success = (boolean) createRopeMethod.invoke(ropeHolderA, ropeHolderB);
-            } catch (Exception ex) {
-                ex.printStackTrace();
+            java.lang.reflect.Method method = getCreateRopeMethod();
+            if (method != null) {
+                if (createRopeMethodNeedsBool) {
+                    success = (boolean) method.invoke(ropeHolderA, ropeHolderB, false);
+                } else {
+                    success = (boolean) method.invoke(ropeHolderA, ropeHolderB);
+                }
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/compartment/CompartmentTracker.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/compartment/CompartmentTracker.java
@@ -252,8 +252,7 @@ public class CompartmentTracker {
             boolean done = CompartmentDetector.stepScan(st, budget);
             if (done) {
                 if (st.chunksMissing) {
-                    // Force quick retry if chunks were missing
-                    // LAST_UPDATE_TICK.put(id, gameTick);
+                    LAST_UPDATE_TICK.put(id, gameTick);
                     STRUCTURE_DIRTY.add(id);
                 } else {
                     CompartmentDetector.Result r = CompartmentDetector.finishScan(st);

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/system/BarometerDisplaySource.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/system/BarometerDisplaySource.java
@@ -23,10 +23,11 @@ public class BarometerDisplaySource extends SingleLineDisplaySource {
         int weakest = be.syncedWeakest;
 
         if (depth <= 0) {
-            return Component.translatable("create_submarine.gui.goggles.barometer.no_pressure").withStyle(ChatFormatting.GRAY);
+            return Component.translatable("create_submarine.gui.goggles.barometer.no_pressure")
+                    .withStyle(ChatFormatting.GRAY);
         }
 
-        int state = 1; // 1 = acceptable, 2 = warning, 3 = critical
+        int state = 1;
         if (weakest != -1) {
             if (depth > weakest) {
                 state = 3;
@@ -38,9 +39,15 @@ public class BarometerDisplaySource extends SingleLineDisplaySource {
         int mode = context.sourceConfig().getInt("DisplayMode");
 
         MutableComponent dangerText;
-        if (state == 3) dangerText = Component.translatable("create_submarine.gui.goggles.barometer.critical").withStyle(ChatFormatting.RED, ChatFormatting.BOLD);
-        else if (state == 2) dangerText = Component.translatable("create_submarine.gui.goggles.barometer.warning").withStyle(ChatFormatting.YELLOW);
-        else dangerText = Component.translatable("create_submarine.gui.goggles.barometer.acceptable").withStyle(ChatFormatting.GREEN);
+        if (state == 3)
+            dangerText = Component.translatable("create_submarine.gui.goggles.barometer.critical")
+                    .withStyle(ChatFormatting.RED, ChatFormatting.BOLD);
+        else if (state == 2)
+            dangerText = Component.translatable("create_submarine.gui.goggles.barometer.warning")
+                    .withStyle(ChatFormatting.YELLOW);
+        else
+            dangerText = Component.translatable("create_submarine.gui.goggles.barometer.acceptable")
+                    .withStyle(ChatFormatting.GREEN);
 
         MutableComponent depthText = Component.literal(depth + "m").withStyle(ChatFormatting.AQUA);
 
@@ -49,7 +56,8 @@ public class BarometerDisplaySource extends SingleLineDisplaySource {
         } else if (mode == 1) {
             return dangerText;
         } else {
-            return Component.literal("").append(depthText).append(Component.literal(" - ").withStyle(ChatFormatting.GRAY)).append(dangerText);
+            return Component.literal("").append(depthText)
+                    .append(Component.literal(" - ").withStyle(ChatFormatting.GRAY)).append(dangerText);
         }
     }
 
@@ -59,16 +67,18 @@ public class BarometerDisplaySource extends SingleLineDisplaySource {
     }
 
     @Override
-    public void initConfigurationWidgets(DisplayLinkContext context, ModularGuiLineBuilder builder, boolean isFirstLine) {
+    public void initConfigurationWidgets(DisplayLinkContext context, ModularGuiLineBuilder builder,
+            boolean isFirstLine) {
         super.initConfigurationWidgets(context, builder, isFirstLine);
-        if (isFirstLine) return;
-        
+        if (!isFirstLine)
+            return;
+
         builder.addSelectionScrollInput(0, 100, (si, label) -> {
             si.forOptions(Arrays.asList(
-                Component.translatable("create_submarine.display_source.mode.depth_only"),
-                Component.translatable("create_submarine.display_source.mode.danger_only"),
-                Component.translatable("create_submarine.display_source.mode.both")
-            )).titled(Component.translatable("create_submarine.display_source.mode.title"));
+                    Component.translatable("create_submarine.display_source.mode.depth_only"),
+                    Component.translatable("create_submarine.display_source.mode.danger_only"),
+                    Component.translatable("create_submarine.display_source.mode.both")))
+                    .titled(Component.translatable("create_submarine.display_source.mode.title"));
         }, "DisplayMode");
     }
 
@@ -79,6 +89,6 @@ public class BarometerDisplaySource extends SingleLineDisplaySource {
 
     @Override
     public int getPassiveRefreshTicks() {
-        return 2;
+        return 20;
     }
 }


### PR DESCRIPTION
SteelCableItem: add a cached reflection helper for RopeStrandHolderBehavior.createRope, detecting and supporting both boolean and no-arg signatures and avoiding repeated lookups/exceptions for compatibility with different mod versions.

CompartmentTracker: restore LAST_UPDATE_TICK.put(...) when chunks are missing to force a quick retry and mark the structure dirty.

BarometerDisplaySource: minor formatting/spacing cleanup, build styled danger/depth text more readably, limit configuration widgets to the first line only, and increase passive refresh ticks from 2 to 20 to reduce update frequency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache `RopeStrandHolderBehavior.createRope` reflection (supports boolean and no-arg) to avoid repeated lookups and improve compatibility across mod versions. Restore compartment quick retry when chunks are missing, and refine the barometer display (limit config to the first line; increase passive refresh from 2 to 20).

<sup>Written for commit 19e41ddba1b89feeb6da3e1cedd9d6ecf3a8407b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Maxenonyme/Create-Deep-Seas/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

