### PR TITLE
Fix server crash - missing files on server side

### DIFF
--- a/src/main/java/com/maxenonyme/createsubmarine/CreateSubmarine.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/CreateSubmarine.java
@@ -57,7 +57,6 @@ public class CreateSubmarine {
         public static final Logger LOGGER = LogUtils.getLogger();
         public static final boolean DISABLE_WATER_OCCLUSION = false;
         public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(BuiltInRegistries.BLOCK, MOD_ID);
-        public static java.util.function.BiPredicate<java.util.UUID, net.minecraft.core.BlockPos> clientCrackCheck = (id, pos) -> false;
         public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(BuiltInRegistries.ITEM, MOD_ID);
         public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister
                         .create(BuiltInRegistries.BLOCK_ENTITY_TYPE, MOD_ID);

--- a/src/main/java/com/maxenonyme/createsubmarine/CreateSubmarineClient.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/CreateSubmarineClient.java
@@ -42,7 +42,7 @@ public final class CreateSubmarineClient {
         modEventBus.addListener(CreateSubmarineClient::onRegisterRenderers);
         modEventBus.addListener(CreateSubmarineClient::onRegisterScreens);
         modEventBus.addListener(CreateSubmarineClient::onRegisterClientExtensions);
-        CreateSubmarine.clientCrackCheck = SubLevelCrackRenderer::hasCrack;
+        com.maxenonyme.createsubmarine.submarine.util.CrackUtil.setChecker(SubLevelCrackRenderer::hasCrack);
 
         modEventBus.addListener(WatermarkOverlay::register);
 

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/mixin/compat/copycat/CopycatWrenchMixin.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/mixin/compat/copycat/CopycatWrenchMixin.java
@@ -43,7 +43,7 @@ public interface CopycatWrenchMixin {
 
             if (level.isClientSide()) {
                 pressurized = sub.logicalPose().position().y() < 62;
-                hasCrack = com.maxenonyme.createsubmarine.CreateSubmarine.clientCrackCheck.test(subId, plotPos);
+                hasCrack = com.maxenonyme.createsubmarine.submarine.util.CrackUtil.hasCrack(subId, plotPos);
             } else {
                 pressurized = com.maxenonyme.createsubmarine.submarine.system.SubmarinePressureSystem.isPressurized(subId);
                 java.util.Map<net.minecraft.core.BlockPos, Integer> cracks = com.maxenonyme.createsubmarine.submarine.system.SubmarinePressureSystem.getAllCracks().get(subId);

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/util/CrackUtil.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/util/CrackUtil.java
@@ -1,0 +1,17 @@
+package com.maxenonyme.createsubmarine.submarine.util;
+
+import java.util.UUID;
+import java.util.function.BiPredicate;
+import net.minecraft.core.BlockPos;
+
+public class CrackUtil {
+    private static BiPredicate<UUID, BlockPos> checker = (id, pos) -> false;
+
+    public static void setChecker(BiPredicate<UUID, BlockPos> impl) {
+        checker = impl;
+    }
+
+    public static boolean hasCrack(UUID subId, BlockPos pos) {
+        return checker.test(subId, pos);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a server crash caused by files not being available on the server side.

## Changes

- **CreateSubmarine.java**: Removed problematic line that caused server-side issues
- **CreateSubmarineClient.java**: Fixed client-only reference that crashed on dedicated servers
- **CopycatWrenchMixin.java**: Fixed mixin that wasn't properly guarded for server compatibility  
- **CrackUtil.java**: Added utility class for block cracking, previously missing from server builds

## Testing

- Server no longer crashes on startup
- All existing functionality preserved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a dedicated server startup crash by removing client-only references and adding a server-safe crack check utility. Servers now start cleanly; client behavior is unchanged.

- **Bug Fixes**
  - Removed the `clientCrackCheck` field from `CreateSubmarine` that leaked client code into server.
  - Added `com.maxenonyme.createsubmarine.submarine.util.CrackUtil` to encapsulate crack checks (defaults to no-op on server).
  - Wired the client checker in `CreateSubmarineClient` via `CrackUtil.setChecker(SubLevelCrackRenderer::hasCrack)`.
  - Updated `CopycatWrenchMixin` to call `CrackUtil.hasCrack` on client and keep server logic server-safe.

<sup>Written for commit 343127549c03da0a3a708eb110102af640776b95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Maxenonyme/Create-Deep-Seas/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

