### PR TITLE
Changed SablePhysicsHelper to QueuedForceGroup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ configurations {
 }
 
 dependencies {
-    implementation "curse.maven:create-328085:${create_file_id}"
+    implementation "maven.modrinth:create:6.0.10+mc1.21.1"
     implementation "net.createmod.ponder:ponder-neoforge:1.0.82+mc1.21.1"
     implementation "dev.engine-room.flywheel:flywheel-neoforge-1.21.1:1.0.6"
     implementation "foundry.veil:veil-neoforge-1.21.1:3.6.2"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ parchment_mappings_version=2024.11.17
 
 minecraft_version=1.21.1
 minecraft_version_range=[1.21.1]
-neo_version=21.1.227
+neo_version=21.1.228
 neo_version_range=[21.1,)
 loader_version_range=[1,)
 

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/BallastTankBlockEntity.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/BallastTankBlockEntity.java
@@ -40,7 +40,7 @@ public class BallastTankBlockEntity extends BlockEntity
         implements IHaveGoggleInformation, dev.ryanhcode.sable.api.block.BlockEntitySubLevelActor {
     private static final int CAPACITY = 8000;
     private static final Map<UUID, Double> TICK_TOTAL_FORCE = new HashMap<>();
-    private static long lastClearTick = -1;
+    private static double lastTimeStep = -1;
 
     // Updated by the normal server tick and consumed by the physics tick.
     private volatile boolean cachedUnderwater;
@@ -405,10 +405,10 @@ public class BallastTankBlockEntity extends BlockEntity
         if (this != getMaster() || handle == null || !handle.isValid())
             return;
 
-        long gameTick = level.getGameTime();
-        if (gameTick != lastClearTick) {
+
+        if (timeStep != lastTimeStep) {
             TICK_TOTAL_FORCE.clear();
-            lastClearTick = gameTick;
+            lastTimeStep = timeStep;
         }
 
         List<BallastTankBlockEntity> cluster = getCluster();

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/BallastTankBlockEntity.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/BallastTankBlockEntity.java
@@ -2,9 +2,12 @@ package com.maxenonyme.createsubmarine.submarine.block.entity;
 
 import com.maxenonyme.createsubmarine.CreateSubmarine;
 import com.simibubi.create.api.equipment.goggles.IHaveGoggleInformation;
+
+import dev.ryanhcode.sable.api.physics.handle.RigidBodyHandle;
 import dev.ryanhcode.sable.companion.SableCompanion;
 import dev.ryanhcode.sable.companion.SubLevelAccess;
-import java.util.UUID;
+import dev.ryanhcode.sable.sublevel.ServerSubLevel;
+
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -22,24 +25,21 @@ import net.neoforged.neoforge.fluids.capability.IFluidHandler.FluidAction;
 import net.neoforged.neoforge.fluids.capability.templates.FluidTank;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3d;
-import org.joml.Vector3dc;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.UUID;
 
 public class BallastTankBlockEntity extends BlockEntity
         implements IHaveGoggleInformation, dev.ryanhcode.sable.api.block.BlockEntitySubLevelActor {
-    private org.joml.Vector3d recordedForceVec = null;
     private static final int CAPACITY = 8000;
-    private static final double MAX_ACCEL_LIMIT = 0.2;
-    private static long lastClearTick = -1;
-    private static final Map<UUID, Double> TICK_TOTAL_FORCE = new HashMap<>();
+
+    // Updated by the normal server tick and consumed by the physics tick.
+    private boolean cachedUnderwater;
+    private double cachedSubmergedRatio;
+    private double cachedDistanceToSurface;
     public final FluidTank tank = new FluidTank(CAPACITY) {
         @Override
         protected void onContentsChanged() {
@@ -251,26 +251,19 @@ public class BallastTankBlockEntity extends BlockEntity
     public static void serverTick(Level level, BlockPos pos, BallastTankBlockEntity be) {
         if (level.isClientSide())
             return;
+
         be.shareFluidWithNeighbors();
-        SubLevelAccess sub = SableCompanion.INSTANCE.getContaining(level, pos);
-        if (sub == null)
+        be.clearCachedWaterState();
+
+        SubLevelAccess access = SableCompanion.INSTANCE.getContaining(level, pos);
+        if (!(access instanceof ServerSubLevel sub))
             return;
-        double fillRatio = (double) be.tank.getFluidAmount() / CAPACITY;
-        long gameTick = level.getGameTime();
-        if (gameTick != lastClearTick) {
-            TICK_TOTAL_FORCE.clear();
-            lastClearTick = gameTick;
-        }
-        UUID subId = sub.getUniqueId();
 
         Vector3d worldPos = new Vector3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
         sub.logicalPose().transformPosition(worldPos);
 
-        Object handle = com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper.getHandle(sub);
-        Vector3dc currentVel = com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper.getVelocity(handle);
-        double currentVelY = (currentVel != null) ? currentVel.y() : 0;
-
-        Level parentLevel = com.maxenonyme.createsubmarine.submarine.util.SubLevelRegistry.getLevel(sub.getUniqueId());
+        Level parentLevel = com.maxenonyme.createsubmarine.submarine.util.SubLevelRegistry
+                .getLevel(sub.getUniqueId());
         if (parentLevel == null && sub instanceof dev.ryanhcode.sable.sublevel.SubLevel sl) {
             dev.ryanhcode.sable.sublevel.plot.LevelPlot plot = sl.getPlot();
             if (plot != null && sl.getLevel() != null) {
@@ -278,8 +271,9 @@ public class BallastTankBlockEntity extends BlockEntity
                 dev.ryanhcode.sable.companion.math.BoundingBox3ic bounds = plot.getBoundingBox();
                 com.maxenonyme.createsubmarine.submarine.util.SubLevelRegistry.register(
                         sub.getUniqueId(), sub, parentLevel,
-                        new com.maxenonyme.createsubmarine.submarine.util.SubLevelRegistry.PlotBounds(bounds.minX(),
-                                bounds.maxX(), bounds.minY(), bounds.maxY(), bounds.minZ(), bounds.maxZ()));
+                        new com.maxenonyme.createsubmarine.submarine.util.SubLevelRegistry.PlotBounds(
+                                bounds.minX(), bounds.maxX(), bounds.minY(), bounds.maxY(),
+                                bounds.minZ(), bounds.maxZ()));
             }
         }
 
@@ -287,73 +281,43 @@ public class BallastTankBlockEntity extends BlockEntity
             return;
 
         BlockPos parentPos = BlockPos.containing(worldPos.x, worldPos.y, worldPos.z);
-        double localWaterSurfaceY = -999.0;
-
-        net.minecraft.world.level.material.FluidState fluidState = com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
-                .realFluidState(parentLevel, parentPos);
-        if (fluidState.is(net.minecraft.tags.FluidTags.WATER)) {
-            float h = fluidState.getHeight(parentLevel, parentPos);
-            localWaterSurfaceY = parentPos.getY() + h + countWaterAbove(parentLevel, parentPos);
-        } else {
-            BlockPos belowPos = parentPos.below();
-            net.minecraft.world.level.material.FluidState belowFluid = com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
-                    .realFluidState(parentLevel, belowPos);
-            if (belowFluid.is(net.minecraft.tags.FluidTags.WATER)) {
-                float h = belowFluid.getHeight(parentLevel, belowPos);
-                localWaterSurfaceY = belowPos.getY() + h + countWaterAbove(parentLevel, belowPos);
-            }
-        }
-
-        double depth = localWaterSurfaceY - (worldPos.y - 0.5);
-        boolean isUnderWater = (depth > 0.0);
-
-        if (!isUnderWater)
+        double waterSurfaceY = findWaterSurface(parentLevel, parentPos);
+        if (!Double.isFinite(waterSurfaceY))
             return;
 
-        double submergedRatio = Math.max(0.0, Math.min(1.0, depth));
+        double depth = waterSurfaceY - (worldPos.y - 0.5);
+        if (depth <= 0.0)
+            return;
 
-        double maxSpeed = com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig.BALLAST_VERTICAL_SPEED.get();
-        double baseTarget = (0.5 - fillRatio) * 2.0 * maxSpeed;
-        double distanceToSurface = localWaterSurfaceY - worldPos.y;
-        double targetVelY;
-        if (baseTarget > 0) {
-            targetVelY = Math.max(-0.1, Math.min(baseTarget, distanceToSurface));
-        } else {
-            targetVelY = baseTarget;
+        be.cachedUnderwater = true;
+        be.cachedSubmergedRatio = Math.clamp(depth, 0.0, 1.0);
+        be.cachedDistanceToSurface = waterSurfaceY - worldPos.y;
+    }
+
+    private void clearCachedWaterState() {
+        cachedUnderwater = false;
+        cachedSubmergedRatio = 0.0;
+        cachedDistanceToSurface = 0.0;
+    }
+
+    private static double findWaterSurface(Level level, BlockPos pos) {
+        net.minecraft.world.level.material.FluidState fluidState =
+                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
+                        .realFluidState(level, pos);
+        if (fluidState.is(net.minecraft.tags.FluidTags.WATER)) {
+            return pos.getY() + fluidState.getHeight(level, pos) + countWaterAbove(level, pos);
         }
 
-        double perceivedVelY = Math.max(-0.2, Math.min(0.2, currentVelY));
-        double errorY = targetVelY - perceivedVelY;
-        double mass = com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper.readMass(sub);
-
-        double forceMult = com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig.BALLAST_FORCE_MULTIPLIER
-                .get();
-        double liftPerTank = com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig.BALLAST_LIFT_PER_TANK
-                .get();
-        double forceToApply = errorY * liftPerTank * 0.16 * forceMult * submergedRatio;
-
-        if (Double.isFinite(forceToApply)) {
-            applyForce(sub, forceToApply);
-            double finalForce = (Math.abs(currentVelY) < 0.01 && forceToApply < 0) ? forceToApply * 0.1 : forceToApply;
-            org.joml.Vector3d forceVec = new org.joml.Vector3d(0, finalForce, 0);
-            sub.logicalPose().orientation().conjugate(new org.joml.Quaterniond()).transform(forceVec);
-            be.recordedForceVec = forceVec;
+        BlockPos belowPos = pos.below();
+        net.minecraft.world.level.material.FluidState belowFluid =
+                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
+                        .realFluidState(level, belowPos);
+        if (belowFluid.is(net.minecraft.tags.FluidTags.WATER)) {
+            return belowPos.getY() + belowFluid.getHeight(level, belowPos)
+                    + countWaterAbove(level, belowPos);
         }
 
-        if (subId != null && !TICK_TOTAL_FORCE.containsKey(subId)) {
-            TICK_TOTAL_FORCE.put(subId, 1.0);
-            if (handle != null && currentVel != null) {
-                double dragCoefficient = 0.035;
-                double dragX = -currentVel.x() * mass * dragCoefficient;
-                double dragZ = -currentVel.z() * mass * dragCoefficient;
-                if (Math.abs(dragX) > 0.01 || Math.abs(dragZ) > 0.01) {
-                    Vector3d dragVec = new Vector3d(dragX, 0, dragZ);
-                    sub.logicalPose().orientation().conjugate(new org.joml.Quaterniond()).transform(dragVec);
-                    com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper.applyLinearImpulse(handle,
-                            dragVec);
-                }
-            }
-        }
+        return Double.NaN;
     }
 
     private void shareFluidWithNeighbors() {
@@ -421,19 +385,11 @@ public class BallastTankBlockEntity extends BlockEntity
         return depth;
     }
 
-    private static void applyForce(SubLevelAccess sub, double forceY) {
-        Object handle = com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper.getHandle(sub);
-        if (handle == null)
-            return;
-        com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper.wakeUp(handle);
-        double velY = 0;
-        Vector3dc vel = com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper.getVelocity(handle);
-        if (vel != null)
-            velY = vel.y();
-        double finalForce = (Math.abs(velY) < 0.01 && forceY < 0) ? forceY * 0.1 : forceY;
-        Vector3d forceVec = new Vector3d(0, finalForce, 0);
-        sub.logicalPose().orientation().conjugate(new org.joml.Quaterniond()).transform(forceVec);
-        com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper.applyLinearImpulse(handle, forceVec);
+    private static Vector3d worldToLocal(SubLevelAccess sub, Vector3d vector) {
+        return sub.logicalPose()
+                .orientation()
+                .conjugate(new org.joml.Quaterniond())
+                .transform(vector);
     }
 
     @Override
@@ -479,38 +435,95 @@ public class BallastTankBlockEntity extends BlockEntity
     }
 
     @Override
-    public void sable$physicsTick(dev.ryanhcode.sable.sublevel.ServerSubLevel sub,
-            dev.ryanhcode.sable.api.physics.handle.RigidBodyHandle handle, double timeStep) {
-        if (this.recordedForceVec == null)
-            return;
-        if (this != getMaster())
+    public void sable$physicsTick(ServerSubLevel sub, RigidBodyHandle handle, double timeStep) {
+        if (this != getMaster() || handle == null || !handle.isValid())
             return;
 
-        if (sub.isTrackingIndividualQueuedForces()) {
-            dev.ryanhcode.sable.api.physics.force.QueuedForceGroup forceGroup = sub.getOrCreateQueuedForceGroup(
-                    com.maxenonyme.createsubmarine.CreateSubmarine.BALLAST_FORCE_GROUP.get());
-            org.joml.Vector3d totalForce = new org.joml.Vector3d();
-            org.joml.Vector3d centerPos = new org.joml.Vector3d();
-            List<BallastTankBlockEntity> cluster = getCluster();
-            int count = 0;
-            for (BallastTankBlockEntity be : cluster) {
-                if (be.recordedForceVec != null) {
-                    totalForce.add(be.recordedForceVec);
-                    centerPos.add(be.worldPosition.getX() + 0.5, be.worldPosition.getY() + 0.5,
-                            be.worldPosition.getZ() + 0.5);
-                    be.recordedForceVec = null;
-                    count++;
-                }
-            }
-            if (count > 0) {
-                centerPos.div(count);
-                org.joml.Vector3d recordVec = totalForce.mul(20.0 * timeStep);
-                forceGroup.recordPointForce(centerPos, recordVec);
-            }
-        } else {
-            for (BallastTankBlockEntity be : getCluster()) {
-                be.recordedForceVec = null;
-            }
+        List<BallastTankBlockEntity> cluster = getCluster();
+        Vector3d velocity = handle.getLinearVelocity(new Vector3d());
+        dev.ryanhcode.sable.api.physics.force.QueuedForceGroup forceGroup =
+                sub.getOrCreateQueuedForceGroup(CreateSubmarine.BALLAST_FORCE_GROUP.get());
+
+        boolean anyTankUnderwater = false;
+        Vector3d clusterCenter = new Vector3d();
+
+        for (BallastTankBlockEntity tankEntity : cluster) {
+            clusterCenter.add(
+                    tankEntity.worldPosition.getX() + 0.5,
+                    tankEntity.worldPosition.getY() + 0.5,
+                    tankEntity.worldPosition.getZ() + 0.5);
+
+            if (!tankEntity.cachedUnderwater)
+                continue;
+
+            anyTankUnderwater = true;
+            double impulseY = calculateBallastImpulseY(tankEntity, velocity.y(), timeStep);
+            if (!Double.isFinite(impulseY) || Math.abs(impulseY) <= 1.0e-9)
+                continue;
+
+            Vector3d localPoint = new Vector3d(
+                    tankEntity.worldPosition.getX() + 0.5,
+                    tankEntity.worldPosition.getY() + 0.5,
+                    tankEntity.worldPosition.getZ() + 0.5);
+            Vector3d localImpulse = worldToLocal(sub, new Vector3d(0.0, impulseY, 0.0));
+            forceGroup.applyAndRecordPointForce(localPoint, localImpulse);
         }
+
+        if (!anyTankUnderwater || cluster.isEmpty())
+            return;
+
+        clusterCenter.div(cluster.size());
+        applyHorizontalDrag(sub, forceGroup, clusterCenter, velocity, timeStep);
     }
+
+    private static double calculateBallastImpulseY(
+            BallastTankBlockEntity tankEntity, double currentVelocityY, double timeStep) {
+        double fillRatio = (double) tankEntity.tank.getFluidAmount() / CAPACITY;
+        double maxSpeed = com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig
+                .BALLAST_VERTICAL_SPEED.get();
+        double targetVelocityY = (0.5 - fillRatio) * 2.0 * maxSpeed;
+
+        if (targetVelocityY > 0.0) {
+            targetVelocityY = Math.max(-0.1,
+                    Math.min(targetVelocityY, tankEntity.cachedDistanceToSurface));
+        }
+
+        double perceivedVelocityY = Math.clamp(currentVelocityY, -0.2, 0.2);
+        double velocityError = targetVelocityY - perceivedVelocityY;
+        double forceMultiplier = com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig
+                .BALLAST_FORCE_MULTIPLIER.get();
+        double liftPerTank = com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig
+                .BALLAST_LIFT_PER_TANK.get();
+
+        // The old implementation applied this value once per game tick. 
+        // Now its calculated based on timestep.
+        double impulseY = velocityError * liftPerTank * 0.16 * forceMultiplier
+                * tankEntity.cachedSubmergedRatio * 20.0 * timeStep;
+
+        if (Math.abs(currentVelocityY) < 0.01 && impulseY < 0.0)
+            impulseY *= 0.1;
+
+        return impulseY;
+    }
+
+    private static void applyHorizontalDrag(
+            ServerSubLevel sub,
+            dev.ryanhcode.sable.api.physics.force.QueuedForceGroup forceGroup,
+            Vector3d localPoint,
+            Vector3d velocity,
+            double timeStep) {
+        double mass = sub.getMassTracker().getMass();
+        double dragCoefficient = 0.035;
+        double impulseScale = 20.0 * timeStep;
+        double impulseX = -velocity.x() * mass * dragCoefficient * impulseScale;
+        double impulseZ = -velocity.z() * mass * dragCoefficient * impulseScale;
+
+        if (Math.abs(impulseX) <= 0.01 && Math.abs(impulseZ) <= 0.01)
+            return;
+
+        Vector3d localImpulse = worldToLocal(sub, new Vector3d(impulseX, 0.0, impulseZ));
+        forceGroup.applyAndRecordPointForce(localPoint, localImpulse);
+    }
+
 }
+

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/BallastTankBlockEntity.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/BallastTankBlockEntity.java
@@ -27,15 +27,20 @@ import net.neoforged.neoforge.fluids.capability.templates.FluidTank;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3d;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.UUID;
 
 public class BallastTankBlockEntity extends BlockEntity
         implements IHaveGoggleInformation, dev.ryanhcode.sable.api.block.BlockEntitySubLevelActor {
     private static final int CAPACITY = 8000;
+    private static final Map<UUID, Double> TICK_TOTAL_FORCE = new HashMap<>();
+    private static long lastClearTick = -1;
 
     // Updated by the normal server tick and consumed by the physics tick.
     private volatile boolean cachedUnderwater;
@@ -283,8 +288,10 @@ public class BallastTankBlockEntity extends BlockEntity
 
         BlockPos parentPos = BlockPos.containing(worldPos.x, worldPos.y, worldPos.z);
         double waterSurfaceY = WaterUtil.findWaterSurface(parentLevel, parentPos);
-        if (!Double.isFinite(waterSurfaceY))
+        if (!Double.isFinite(waterSurfaceY)) {
+            be.clearCachedWaterState();
             return;
+        }
 
         double depth = waterSurfaceY - (worldPos.y - 0.5);
         if (depth <= 0.0)
@@ -398,6 +405,12 @@ public class BallastTankBlockEntity extends BlockEntity
         if (this != getMaster() || handle == null || !handle.isValid())
             return;
 
+        long gameTick = level.getGameTime();
+        if (gameTick != lastClearTick) {
+            TICK_TOTAL_FORCE.clear();
+            lastClearTick = gameTick;
+        }
+
         List<BallastTankBlockEntity> cluster = getCluster();
         Vector3d velocity = handle.getLinearVelocity(new Vector3d());
         dev.ryanhcode.sable.api.physics.force.QueuedForceGroup forceGroup =
@@ -432,7 +445,12 @@ public class BallastTankBlockEntity extends BlockEntity
             return;
 
         clusterCenter.div(cluster.size());
-        applyHorizontalDrag(sub, forceGroup, clusterCenter, velocity, timeStep);
+
+        UUID subId = sub.getUniqueId();
+        if (subId != null && !TICK_TOTAL_FORCE.containsKey(subId)) {
+            TICK_TOTAL_FORCE.put(subId, 1.0);
+            applyHorizontalDrag(sub, forceGroup, clusterCenter, velocity, timeStep);
+        }
     }
 
     private static double calculateBallastImpulseY(

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/BallastTankBlockEntity.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/BallastTankBlockEntity.java
@@ -1,6 +1,7 @@
 package com.maxenonyme.createsubmarine.submarine.block.entity;
 
 import com.maxenonyme.createsubmarine.CreateSubmarine;
+import com.maxenonyme.createsubmarine.submarine.util.WaterUtil;
 import com.simibubi.create.api.equipment.goggles.IHaveGoggleInformation;
 
 import dev.ryanhcode.sable.api.physics.handle.RigidBodyHandle;
@@ -37,9 +38,9 @@ public class BallastTankBlockEntity extends BlockEntity
     private static final int CAPACITY = 8000;
 
     // Updated by the normal server tick and consumed by the physics tick.
-    private boolean cachedUnderwater;
-    private double cachedSubmergedRatio;
-    private double cachedDistanceToSurface;
+    private volatile boolean cachedUnderwater;
+    private volatile double cachedSubmergedRatio;
+    private volatile double cachedDistanceToSurface;
     public final FluidTank tank = new FluidTank(CAPACITY) {
         @Override
         protected void onContentsChanged() {
@@ -281,7 +282,7 @@ public class BallastTankBlockEntity extends BlockEntity
             return;
 
         BlockPos parentPos = BlockPos.containing(worldPos.x, worldPos.y, worldPos.z);
-        double waterSurfaceY = findWaterSurface(parentLevel, parentPos);
+        double waterSurfaceY = WaterUtil.findWaterSurface(parentLevel, parentPos);
         if (!Double.isFinite(waterSurfaceY))
             return;
 
@@ -298,26 +299,6 @@ public class BallastTankBlockEntity extends BlockEntity
         cachedUnderwater = false;
         cachedSubmergedRatio = 0.0;
         cachedDistanceToSurface = 0.0;
-    }
-
-    private static double findWaterSurface(Level level, BlockPos pos) {
-        net.minecraft.world.level.material.FluidState fluidState =
-                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
-                        .realFluidState(level, pos);
-        if (fluidState.is(net.minecraft.tags.FluidTags.WATER)) {
-            return pos.getY() + fluidState.getHeight(level, pos) + countWaterAbove(level, pos);
-        }
-
-        BlockPos belowPos = pos.below();
-        net.minecraft.world.level.material.FluidState belowFluid =
-                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
-                        .realFluidState(level, belowPos);
-        if (belowFluid.is(net.minecraft.tags.FluidTags.WATER)) {
-            return belowPos.getY() + belowFluid.getHeight(level, belowPos)
-                    + countWaterAbove(level, belowPos);
-        }
-
-        return Double.NaN;
     }
 
     private void shareFluidWithNeighbors() {
@@ -368,28 +349,6 @@ public class BallastTankBlockEntity extends BlockEntity
                     .append(Component.literal(": " + cluster.size()).withStyle(ChatFormatting.GRAY)));
         }
         return true;
-    }
-
-    private static int countWaterAbove(Level level, BlockPos pos) {
-        int depth = 0;
-        BlockPos.MutableBlockPos m = new BlockPos.MutableBlockPos();
-        for (int y = pos.getY() + 1; y < pos.getY() + 1 + 200; y++) {
-            m.set(pos.getX(), y, pos.getZ());
-            if (com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.realFluidState(level, m)
-                    .is(net.minecraft.tags.FluidTags.WATER)) {
-                depth++;
-            } else {
-                break;
-            }
-        }
-        return depth;
-    }
-
-    private static Vector3d worldToLocal(SubLevelAccess sub, Vector3d vector) {
-        return sub.logicalPose()
-                .orientation()
-                .conjugate(new org.joml.Quaterniond())
-                .transform(vector);
     }
 
     @Override
@@ -465,7 +424,7 @@ public class BallastTankBlockEntity extends BlockEntity
                     tankEntity.worldPosition.getX() + 0.5,
                     tankEntity.worldPosition.getY() + 0.5,
                     tankEntity.worldPosition.getZ() + 0.5);
-            Vector3d localImpulse = worldToLocal(sub, new Vector3d(0.0, impulseY, 0.0));
+            Vector3d localImpulse = WaterUtil.worldToLocal(sub, new Vector3d(0.0, impulseY, 0.0));
             forceGroup.applyAndRecordPointForce(localPoint, localImpulse);
         }
 
@@ -521,7 +480,7 @@ public class BallastTankBlockEntity extends BlockEntity
         if (Math.abs(impulseX) <= 0.01 && Math.abs(impulseZ) <= 0.01)
             return;
 
-        Vector3d localImpulse = worldToLocal(sub, new Vector3d(impulseX, 0.0, impulseZ));
+        Vector3d localImpulse = WaterUtil.worldToLocal(sub, new Vector3d(impulseX, 0.0, impulseZ));
         forceGroup.applyAndRecordPointForce(localPoint, localImpulse);
     }
 

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/FloaterBlockEntity.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/FloaterBlockEntity.java
@@ -38,8 +38,6 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
         if (level.isClientSide())
             return;
 
-        be.getCluster();
-
         SubLevelAccess sub = SableCompanion.INSTANCE.getContaining(level, pos);
         boolean sealed = sub != null
                 && com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
@@ -77,7 +75,7 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
         }
 
         if (sub == null) {
-            be.clearCachedEnvironment();
+            be.clearCachedWaterState();
             return;
         }
 
@@ -92,14 +90,16 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
             parentLevel = sl.getLevel();
 
         if (parentLevel == null) {
-            be.clearCachedEnvironment();
+            be.clearCachedWaterState();
             return;
         }
 
         BlockPos parentPos = BlockPos.containing(worldPos.x, worldPos.y, worldPos.z);
         double localWaterSurfaceY = WaterUtil.findWaterSurface(parentLevel, parentPos);
-        if (!Double.isFinite(localWaterSurfaceY))
+        if (!Double.isFinite(localWaterSurfaceY)) {
+            be.clearCachedWaterState();
             return;
+        }
 
         double depth = localWaterSurfaceY - (worldPos.y - 0.5);
 
@@ -112,7 +112,7 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
             checkCrash(level, pos, parentLevel, parentPos, vel);
     }
 
-    private void clearCachedEnvironment() {
+    private void clearCachedWaterState() {
         cachedUnderwater = false;
         cachedSubmergedRatio = 0.0;
         cachedDistanceToSurface = 0.0;

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/FloaterBlockEntity.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/FloaterBlockEntity.java
@@ -1,8 +1,9 @@
 package com.maxenonyme.createsubmarine.submarine.block.entity;
 
 import com.maxenonyme.createsubmarine.CreateSubmarine;
-import com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper;
 import com.maxenonyme.createsubmarine.submarine.util.SubLevelRegistry;
+import dev.ryanhcode.sable.api.physics.force.QueuedForceGroup;
+import dev.ryanhcode.sable.api.physics.handle.RigidBodyHandle;
 import dev.ryanhcode.sable.companion.SableCompanion;
 import dev.ryanhcode.sable.companion.SubLevelAccess;
 import net.minecraft.core.BlockPos;
@@ -15,110 +16,123 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sable.api.block.BlockEntitySubLevelActor {
-    private org.joml.Vector3d recordedForceVec = null;
     private static final int PRESSURE_THRESHOLD = 50;
     private static final int PRESSURE_CHECK_INTERVAL = 20;
     private static final int MAX_WATER_SCAN = 200;
 
     private int pressureTickCounter = 0;
+    private boolean cachedUnderwater;
+    private double cachedSubmergedRatio;
+    private double cachedDistanceToSurface;
+    private final Vector3d cachedVelocity = new Vector3d();
+    private boolean hasCachedVelocity;
 
     public FloaterBlockEntity(BlockPos pos, BlockState state) {
         super(CreateSubmarine.FLOATER_BE.get(), pos, state);
     }
 
     public static void serverTick(Level level, BlockPos pos, FloaterBlockEntity be) {
+        if (level.isClientSide())
+            return;
+
         SubLevelAccess sub = SableCompanion.INSTANCE.getContaining(level, pos);
         boolean sealed = sub != null
-                && com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.hasAnySealed(sub.getUniqueId());
+                && com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
+                        .hasAnySealed(sub.getUniqueId());
 
         if (++be.pressureTickCounter >= PRESSURE_CHECK_INTERVAL) {
             be.pressureTickCounter = 0;
+
             Level worldLevel = level;
             BlockPos worldPos = pos;
             if (sub != null) {
                 Level parent = SubLevelRegistry.getLevel(sub.getUniqueId());
                 if (parent != null)
                     worldLevel = parent;
-                Vector3d wp = new Vector3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
-                sub.logicalPose().transformPosition(wp);
-                worldPos = BlockPos.containing(wp.x, wp.y, wp.z);
+
+                Vector3d transformedPos = new Vector3d(
+                        pos.getX() + 0.5,
+                        pos.getY() + 0.5,
+                        pos.getZ() + 0.5);
+                sub.logicalPose().transformPosition(transformedPos);
+                worldPos = BlockPos.containing(transformedPos.x, transformedPos.y, transformedPos.z);
             }
+
             int threshold = PRESSURE_THRESHOLD;
-            net.minecraft.world.level.block.state.BlockState blockState = level.getBlockState(pos);
-            java.util.Optional<com.maxenonyme.createsubmarine.submarine.config.HullStrengthConfig.HullProperty> propOpt = com.maxenonyme.createsubmarine.submarine.config.HullStrengthConfig.getFor(blockState);
-            if (propOpt.isPresent()) {
+            BlockState blockState = level.getBlockState(pos);
+            java.util.Optional<com.maxenonyme.createsubmarine.submarine.config.HullStrengthConfig.HullProperty> propOpt =
+                    com.maxenonyme.createsubmarine.submarine.config.HullStrengthConfig.getFor(blockState);
+            if (propOpt.isPresent())
                 threshold = propOpt.get().maxWaterDepth();
-            }
+
             if (sealed && countWaterAbove(worldLevel, worldPos) > threshold) {
                 burst(level, pos);
                 return;
             }
         }
 
-        if (sub == null)
+        if (sub == null) {
+            be.clearCachedEnvironment();
             return;
+        }
 
-        Vector3d worldPos = new Vector3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
+        Vector3d worldPos = new Vector3d(
+                pos.getX() + 0.5,
+                pos.getY() + 0.5,
+                pos.getZ() + 0.5);
         sub.logicalPose().transformPosition(worldPos);
 
-        Object handle = SablePhysicsHelper.getHandle(sub);
-        Vector3dc currentVel = SablePhysicsHelper.getVelocity(handle);
-        double currentVelY = (currentVel != null) ? currentVel.y() : 0;
-
         Level parentLevel = SubLevelRegistry.getLevel(sub.getUniqueId());
-        if (parentLevel == null && sub instanceof dev.ryanhcode.sable.sublevel.SubLevel sl) {
+        if (parentLevel == null && sub instanceof dev.ryanhcode.sable.sublevel.SubLevel sl)
             parentLevel = sl.getLevel();
-        }
 
-        if (parentLevel == null)
+        if (parentLevel == null) {
+            be.clearCachedEnvironment();
             return;
+        }
 
         BlockPos parentPos = BlockPos.containing(worldPos.x, worldPos.y, worldPos.z);
-        double localWaterSurfaceY = -999.0;
-
-        net.minecraft.world.level.material.FluidState fluidState = com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.realFluidState(parentLevel, parentPos);
-        if (fluidState.is(FluidTags.WATER)) {
-            float h = fluidState.getHeight(parentLevel, parentPos);
-            localWaterSurfaceY = parentPos.getY() + h + countWaterAbove(parentLevel, parentPos);
-        } else {
-            BlockPos belowPos = parentPos.below();
-            net.minecraft.world.level.material.FluidState belowFluid = com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.realFluidState(parentLevel, belowPos);
-            if (belowFluid.is(FluidTags.WATER)) {
-                float h = belowFluid.getHeight(parentLevel, belowPos);
-                localWaterSurfaceY = belowPos.getY() + h + countWaterAbove(parentLevel, belowPos);
-            }
-        }
+        double localWaterSurfaceY = findWaterSurface(parentLevel, parentPos);
 
         double depth = localWaterSurfaceY - (worldPos.y - 0.5);
-        boolean isUnderWater = (depth > 0.0);
 
-        if (!isUnderWater) {
-            if (sealed) checkCrash(level, pos, parentLevel, parentPos, currentVel);
-            return;
+        be.cachedUnderwater = depth > 0.0;
+        be.cachedSubmergedRatio = Math.max(0.0, Math.min(1.0, depth));
+        be.cachedDistanceToSurface = localWaterSurfaceY - worldPos.y;
+
+        if (sealed && be.hasCachedVelocity)
+            checkCrash(level, pos, parentLevel, parentPos, be.cachedVelocity);
+    }
+
+    private void clearCachedEnvironment() {
+        cachedUnderwater = false;
+        cachedSubmergedRatio = 0.0;
+        cachedDistanceToSurface = 0.0;
+    }
+
+    private static double findWaterSurface(Level parentLevel, BlockPos parentPos) {
+        net.minecraft.world.level.material.FluidState fluidState =
+                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
+                        .realFluidState(parentLevel, parentPos);
+
+        if (fluidState.is(FluidTags.WATER)) {
+            float height = fluidState.getHeight(parentLevel, parentPos);
+            return parentPos.getY() + height + countWaterAbove(parentLevel, parentPos);
         }
 
-        if (sealed) checkCrash(level, pos, parentLevel, parentPos, currentVel);
+        BlockPos belowPos = parentPos.below();
+        net.minecraft.world.level.material.FluidState belowFluid =
+                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
+                        .realFluidState(parentLevel, belowPos);
 
-        double submergedRatio = Math.max(0.0, Math.min(1.0, depth));
-        double distanceToSurface = localWaterSurfaceY - worldPos.y;
-        double targetVelY = Math.max(-0.1, Math.min(1.0, distanceToSurface));
-
-        double perceivedVelY = Math.max(-0.2, Math.min(0.2, currentVelY));
-        double errorY = targetVelY - perceivedVelY;
-
-        double forceMult = com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig.BALLAST_FORCE_MULTIPLIER.get();
-        double liftPerFloater = com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig.FLOATER_LIFT.get();
-        double forceToApply = errorY * liftPerFloater * 0.12 * forceMult * submergedRatio;
-
-        if (Double.isFinite(forceToApply)) {
-            org.joml.Vector3d applied = applyForce(sub, forceToApply);
-            if (applied != null) be.recordedForceVec = applied;
+        if (belowFluid.is(FluidTags.WATER)) {
+            float height = belowFluid.getHeight(parentLevel, belowPos);
+            return belowPos.getY() + height + countWaterAbove(parentLevel, belowPos);
         }
+
+        return Double.NEGATIVE_INFINITY;
     }
 
     private static int countWaterAbove(Level level, BlockPos pos) {
@@ -165,26 +179,6 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
         }
     }
 
-    private static org.joml.Vector3d applyForce(SubLevelAccess sub, double forceY) {
-        Object handle = SablePhysicsHelper.getHandle(sub);
-        if (handle == null)
-            return null;
-        SablePhysicsHelper.wakeUp(handle);
-
-        double velY = 0;
-        Vector3dc vel = SablePhysicsHelper.getVelocity(handle);
-        if (vel != null)
-            velY = vel.y();
-
-        double finalForce = (Math.abs(velY) < 0.01 && forceY < 0) ? forceY * 0.1 : forceY;
-
-        Vector3d forceVec = new Vector3d(0, finalForce, 0);
-        sub.logicalPose().orientation().conjugate(new org.joml.Quaterniond()).transform(forceVec);
-
-        SablePhysicsHelper.applyLinearImpulse(handle, forceVec);
-        return forceVec;
-    }
-
     private java.util.List<FloaterBlockEntity> cachedCluster;
     private long clusterCacheTick = -1;
 
@@ -227,33 +221,71 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
     }
 
     @Override
-    public void sable$physicsTick(dev.ryanhcode.sable.sublevel.ServerSubLevel sub, dev.ryanhcode.sable.api.physics.handle.RigidBodyHandle handle, double timeStep) {
-        if (this.recordedForceVec == null) return;
-        if (this != getMaster()) return;
+    public void sable$physicsTick(
+            dev.ryanhcode.sable.sublevel.ServerSubLevel sub,
+            RigidBodyHandle handle,
+            double timeStep) {
+        if (handle == null || !handle.isValid())
+            return;
 
-        if (sub.isTrackingIndividualQueuedForces()) {
-            dev.ryanhcode.sable.api.physics.force.QueuedForceGroup forceGroup = sub.getOrCreateQueuedForceGroup(com.maxenonyme.createsubmarine.CreateSubmarine.FLOATER_FORCE_GROUP.get());
-            org.joml.Vector3d totalForce = new org.joml.Vector3d();
-            org.joml.Vector3d centerPos = new org.joml.Vector3d();
-            java.util.List<FloaterBlockEntity> cluster = getCluster();
-            int count = 0;
-            for (FloaterBlockEntity be : cluster) {
-                if (be.recordedForceVec != null) {
-                    totalForce.add(be.recordedForceVec);
-                    centerPos.add(be.worldPosition.getX() + 0.5, be.worldPosition.getY() + 0.5, be.worldPosition.getZ() + 0.5);
-                    be.recordedForceVec = null;
-                    count++;
-                }
-            }
-            if (count > 0) {
-                centerPos.div(count);
-                org.joml.Vector3d recordVec = totalForce.mul(20.0 * timeStep);
-                forceGroup.recordPointForce(centerPos, recordVec);
-            }
-        } else {
-            for (FloaterBlockEntity be : getCluster()) {
-                be.recordedForceVec = null;
-            }
+        Vector3d currentVelocity = handle.getLinearVelocity(new Vector3d());
+        cachedVelocity.set(currentVelocity);
+        hasCachedVelocity = true;
+
+        if (this != getMaster())
+            return;
+
+        QueuedForceGroup forceGroup = sub.getOrCreateQueuedForceGroup(
+                CreateSubmarine.FLOATER_FORCE_GROUP.get());
+
+        double perceivedVelY = Math.max(-0.2, Math.min(0.2, currentVelocity.y()));
+        double forceMultiplier =
+                com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig
+                        .BALLAST_FORCE_MULTIPLIER.get();
+        double liftPerFloater =
+                com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig
+                        .FLOATER_LIFT.get();
+        double impulseScale = 20.0 * timeStep;
+
+        for (FloaterBlockEntity floater : getCluster()) {
+            if (!floater.cachedUnderwater)
+                continue;
+
+            double targetVelY = Math.max(
+                    -0.1,
+                    Math.min(1.0, floater.cachedDistanceToSurface));
+            double velocityError = targetVelY - perceivedVelY;
+            double forceY = velocityError
+                    * liftPerFloater
+                    * 0.12
+                    * forceMultiplier
+                    * floater.cachedSubmergedRatio;
+
+            if (!Double.isFinite(forceY))
+                continue;
+
+            double finalForceY =
+                    Math.abs(currentVelocity.y()) < 0.01 && forceY < 0.0
+                            ? forceY * 0.1
+                            : forceY;
+
+            Vector3d localImpulse = worldToLocal(
+                    sub,
+                    new Vector3d(0.0, finalForceY * impulseScale, 0.0));
+            Vector3d localPoint = new Vector3d(
+                    floater.worldPosition.getX() + 0.5,
+                    floater.worldPosition.getY() + 0.5,
+                    floater.worldPosition.getZ() + 0.5);
+
+            forceGroup.applyAndRecordPointForce(localPoint, localImpulse);
         }
     }
+
+    private static Vector3d worldToLocal(SubLevelAccess sub, Vector3d vector) {
+        return sub.logicalPose()
+                .orientation()
+                .conjugate(new org.joml.Quaterniond())
+                .transform(vector);
+    }
+
 }

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/FloaterBlockEntity.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/FloaterBlockEntity.java
@@ -2,6 +2,8 @@ package com.maxenonyme.createsubmarine.submarine.block.entity;
 
 import com.maxenonyme.createsubmarine.CreateSubmarine;
 import com.maxenonyme.createsubmarine.submarine.util.SubLevelRegistry;
+import com.maxenonyme.createsubmarine.submarine.util.WaterUtil;
+
 import dev.ryanhcode.sable.api.physics.force.QueuedForceGroup;
 import dev.ryanhcode.sable.api.physics.handle.RigidBodyHandle;
 import dev.ryanhcode.sable.companion.SableCompanion;
@@ -23,11 +25,10 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
     private static final int MAX_WATER_SCAN = 200;
 
     private int pressureTickCounter = 0;
-    private boolean cachedUnderwater;
-    private double cachedSubmergedRatio;
-    private double cachedDistanceToSurface;
-    private final Vector3d cachedVelocity = new Vector3d();
-    private boolean hasCachedVelocity;
+    private volatile boolean cachedUnderwater;
+    private volatile double cachedSubmergedRatio;
+    private volatile double cachedDistanceToSurface;
+    private volatile Vector3d cachedVelocity = null;
 
     public FloaterBlockEntity(BlockPos pos, BlockState state) {
         super(CreateSubmarine.FLOATER_BE.get(), pos, state);
@@ -36,6 +37,8 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
     public static void serverTick(Level level, BlockPos pos, FloaterBlockEntity be) {
         if (level.isClientSide())
             return;
+
+        be.getCluster();
 
         SubLevelAccess sub = SableCompanion.INSTANCE.getContaining(level, pos);
         boolean sealed = sub != null
@@ -67,7 +70,7 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
             if (propOpt.isPresent())
                 threshold = propOpt.get().maxWaterDepth();
 
-            if (sealed && countWaterAbove(worldLevel, worldPos) > threshold) {
+            if (sealed && WaterUtil.countWaterAbove(worldLevel, worldPos) > threshold) {
                 burst(level, pos);
                 return;
             }
@@ -94,7 +97,9 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
         }
 
         BlockPos parentPos = BlockPos.containing(worldPos.x, worldPos.y, worldPos.z);
-        double localWaterSurfaceY = findWaterSurface(parentLevel, parentPos);
+        double localWaterSurfaceY = WaterUtil.findWaterSurface(parentLevel, parentPos);
+        if (!Double.isFinite(localWaterSurfaceY))
+            return;
 
         double depth = localWaterSurfaceY - (worldPos.y - 0.5);
 
@@ -102,51 +107,15 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
         be.cachedSubmergedRatio = Math.max(0.0, Math.min(1.0, depth));
         be.cachedDistanceToSurface = localWaterSurfaceY - worldPos.y;
 
-        if (sealed && be.hasCachedVelocity)
-            checkCrash(level, pos, parentLevel, parentPos, be.cachedVelocity);
+        Vector3d vel = be.cachedVelocity;
+        if (sealed && vel != null)
+            checkCrash(level, pos, parentLevel, parentPos, vel);
     }
 
     private void clearCachedEnvironment() {
         cachedUnderwater = false;
         cachedSubmergedRatio = 0.0;
         cachedDistanceToSurface = 0.0;
-    }
-
-    private static double findWaterSurface(Level parentLevel, BlockPos parentPos) {
-        net.minecraft.world.level.material.FluidState fluidState =
-                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
-                        .realFluidState(parentLevel, parentPos);
-
-        if (fluidState.is(FluidTags.WATER)) {
-            float height = fluidState.getHeight(parentLevel, parentPos);
-            return parentPos.getY() + height + countWaterAbove(parentLevel, parentPos);
-        }
-
-        BlockPos belowPos = parentPos.below();
-        net.minecraft.world.level.material.FluidState belowFluid =
-                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
-                        .realFluidState(parentLevel, belowPos);
-
-        if (belowFluid.is(FluidTags.WATER)) {
-            float height = belowFluid.getHeight(parentLevel, belowPos);
-            return belowPos.getY() + height + countWaterAbove(parentLevel, belowPos);
-        }
-
-        return Double.NEGATIVE_INFINITY;
-    }
-
-    private static int countWaterAbove(Level level, BlockPos pos) {
-        int depth = 0;
-        BlockPos.MutableBlockPos m = new BlockPos.MutableBlockPos();
-        for (int y = pos.getY() + 1; y < pos.getY() + 1 + MAX_WATER_SCAN; y++) {
-            m.set(pos.getX(), y, pos.getZ());
-            if (com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.realFluidState(level, m).is(FluidTags.WATER)) {
-                depth++;
-            } else {
-                break;
-            }
-        }
-        return depth;
     }
 
     private static void burst(Level level, BlockPos pos) {
@@ -225,12 +194,15 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
             dev.ryanhcode.sable.sublevel.ServerSubLevel sub,
             RigidBodyHandle handle,
             double timeStep) {
-        if (handle == null || !handle.isValid())
+        if (handle == null || !handle.isValid()) {
+            cachedVelocity = null;
             return;
+        }
 
-        Vector3d currentVelocity = handle.getLinearVelocity(new Vector3d());
-        cachedVelocity.set(currentVelocity);
-        hasCachedVelocity = true;
+        
+        Vector3d currentVelocity = new Vector3d();
+        handle.getLinearVelocity(currentVelocity);
+        cachedVelocity = currentVelocity;
 
         if (this != getMaster())
             return;
@@ -269,7 +241,7 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
                             ? forceY * 0.1
                             : forceY;
 
-            Vector3d localImpulse = worldToLocal(
+            Vector3d localImpulse = WaterUtil.worldToLocal(
                     sub,
                     new Vector3d(0.0, finalForceY * impulseScale, 0.0));
             Vector3d localPoint = new Vector3d(
@@ -279,13 +251,6 @@ public class FloaterBlockEntity extends BlockEntity implements dev.ryanhcode.sab
 
             forceGroup.applyAndRecordPointForce(localPoint, localImpulse);
         }
-    }
-
-    private static Vector3d worldToLocal(SubLevelAccess sub, Vector3d vector) {
-        return sub.logicalPose()
-                .orientation()
-                .conjugate(new org.joml.Quaterniond())
-                .transform(vector);
     }
 
 }

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/UnderwaterMineBlockEntity.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/UnderwaterMineBlockEntity.java
@@ -2,17 +2,18 @@ package com.maxenonyme.createsubmarine.submarine.block.entity;
 
 import com.maxenonyme.createsubmarine.CreateSubmarine;
 import com.maxenonyme.createsubmarine.submarine.system.MineOwnershipRegistry;
-import com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper;
 import com.maxenonyme.createsubmarine.submarine.util.SubLevelRegistry;
 import dev.ryanhcode.sable.companion.SableCompanion;
 import dev.ryanhcode.sable.companion.SubLevelAccess;
+import dev.ryanhcode.sable.api.physics.force.QueuedForceGroup;
+import dev.ryanhcode.sable.api.physics.handle.RigidBodyHandle;
+import dev.ryanhcode.sable.sublevel.ServerSubLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.joml.Vector3d;
-import org.joml.Vector3dc;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -32,7 +33,8 @@ import dev.ryanhcode.sable.api.sublevel.SubLevelContainer;
 import dev.ryanhcode.sable.sublevel.SubLevel;
 import dev.ryanhcode.sable.companion.math.BoundingBox3ic;
 
-public class UnderwaterMineBlockEntity extends BlockEntity {
+public class UnderwaterMineBlockEntity extends BlockEntity
+        implements dev.ryanhcode.sable.api.block.BlockEntitySubLevelActor {
     private static final int MAX_WATER_SCAN = 200;
 
     private static final Map<UUID, Set<BlockPos>> ACTIVE_MINES = new ConcurrentHashMap<>();
@@ -41,6 +43,11 @@ public class UnderwaterMineBlockEntity extends BlockEntity {
     private UUID trackedSubId;
     private boolean exceedsLimitCached = false;
     private long lastLimitCheckTick = -1;
+
+    // Updated by serverTick and consumed by the physics callback.
+    private volatile boolean cachedUnderwater = false;
+    private volatile double cachedSubmergedRatio = 0.0;
+    private volatile double cachedDistanceToSurface = 0.0;
 
     public UnderwaterMineBlockEntity(BlockPos pos, BlockState state) {
         super(CreateSubmarine.UNDERWATER_MINE_BE.get(), pos, state);
@@ -112,44 +119,52 @@ public class UnderwaterMineBlockEntity extends BlockEntity {
     }
 
     public static void serverTick(Level level, BlockPos pos, UnderwaterMineBlockEntity be) {
-        if (be.isExploded) return;
-
-        SubLevelAccess sub = SableCompanion.INSTANCE.getContaining(level, pos);
-        if (sub == null)
+        if (be.isExploded)
             return;
 
+        SubLevelAccess sub = SableCompanion.INSTANCE.getContaining(level, pos);
+        if (sub == null) {
+            be.clearCachedWaterState();
+            return;
+        }
+
         UUID subId = sub.getUniqueId();
-        ACTIVE_MINES.computeIfAbsent(subId, k -> ConcurrentHashMap.newKeySet()).add(pos);
+        ACTIVE_MINES.computeIfAbsent(subId, ignored -> ConcurrentHashMap.newKeySet()).add(pos);
         be.trackedSubId = subId;
         MineOwnershipRegistry.tag(subId, be.ownerUUID);
 
-        Vector3d worldPos = new Vector3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
+        Vector3d worldPos = new Vector3d(
+                pos.getX() + 0.5,
+                pos.getY() + 0.5,
+                pos.getZ() + 0.5);
         sub.logicalPose().transformPosition(worldPos);
 
-        Level parentLevel = SubLevelRegistry.getLevel(sub.getUniqueId());
-        if (parentLevel == null && sub instanceof dev.ryanhcode.sable.sublevel.SubLevel sl) {
-            parentLevel = sl.getLevel();
+        Level parentLevel = SubLevelRegistry.getLevel(subId);
+        if (parentLevel == null && sub instanceof SubLevel subLevel) {
+            parentLevel = subLevel.getLevel();
         }
 
-        if (parentLevel == null)
+        if (parentLevel == null) {
+            be.clearCachedWaterState();
             return;
+        }
 
         if (parentLevel instanceof ServerLevel serverParentLevel) {
             AABB triggerBox = new AABB(
                     worldPos.x - 3.0, worldPos.y - 3.0, worldPos.z - 3.0,
                     worldPos.x + 3.0, worldPos.y + 3.0, worldPos.z + 3.0);
+
             java.util.List<Entity> nearbyEntities = serverParentLevel.getEntitiesOfClass(
-                    Entity.class, triggerBox,
-                    e -> {
-                        if (e instanceof net.minecraft.world.entity.vehicle.Boat) {
+                    Entity.class,
+                    triggerBox,
+                    entity -> {
+                        if (entity instanceof net.minecraft.world.entity.vehicle.Boat)
                             return true;
+
+                        if (entity instanceof Player || entity instanceof LivingEntity) {
+                            return be.ownerUUID == null || !entity.getUUID().equals(be.ownerUUID);
                         }
-                        if (e instanceof Player || e instanceof LivingEntity) {
-                            if (be.ownerUUID != null && e.getUUID().equals(be.ownerUUID)) {
-                                return false;
-                            }
-                            return true;
-                        }
+
                         return false;
                     });
 
@@ -158,91 +173,162 @@ public class UnderwaterMineBlockEntity extends BlockEntity {
             if (container != null) {
                 for (SubLevel otherSub : container.getAllSubLevels()) {
                     UUID otherSubId = otherSub.getUniqueId();
-                    if (sub != null && otherSubId.equals(sub.getUniqueId())) {
+                    if (otherSubId.equals(subId))
+                        continue;
+
+                    if (be.ownerUUID != null
+                            && be.ownerUUID.equals(MineOwnershipRegistry.getOwner(otherSubId))) {
                         continue;
                     }
-                    if (be.ownerUUID != null && be.ownerUUID.equals(MineOwnershipRegistry.getOwner(otherSubId))) {
-                        continue;
-                    }
-                    Vector3d localInOther = new Vector3d(worldPos.x, worldPos.y, worldPos.z);
+
+                    Vector3d localInOther = new Vector3d(worldPos);
                     otherSub.logicalPose().transformPositionInverse(localInOther);
 
-                    if (otherSub.getPlot() != null && otherSub.getPlot().getBoundingBox() != null) {
-                        BoundingBox3ic otherBounds = otherSub.getPlot().getBoundingBox();
-                        double dx = Math.max(0.0, Math.max(otherBounds.minX() - localInOther.x, localInOther.x - otherBounds.maxX()));
-                        double dy = Math.max(0.0, Math.max(otherBounds.minY() - localInOther.y, localInOther.y - otherBounds.maxY()));
-                        double dz = Math.max(0.0, Math.max(otherBounds.minZ() - localInOther.z, localInOther.z - otherBounds.maxZ()));
-                        double distanceSq = dx * dx + dy * dy + dz * dz;
-                        if (distanceSq <= 9.0) {
-                            otherSubNearby = true;
-                            break;
-                        }
+                    if (otherSub.getPlot() == null || otherSub.getPlot().getBoundingBox() == null)
+                        continue;
+
+                    BoundingBox3ic otherBounds = otherSub.getPlot().getBoundingBox();
+                    double dx = Math.max(
+                            0.0,
+                            Math.max(
+                                    otherBounds.minX() - localInOther.x,
+                                    localInOther.x - otherBounds.maxX()));
+                    double dy = Math.max(
+                            0.0,
+                            Math.max(
+                                    otherBounds.minY() - localInOther.y,
+                                    localInOther.y - otherBounds.maxY()));
+                    double dz = Math.max(
+                            0.0,
+                            Math.max(
+                                    otherBounds.minZ() - localInOther.z,
+                                    localInOther.z - otherBounds.maxZ()));
+
+                    if (dx * dx + dy * dy + dz * dz <= 9.0) {
+                        otherSubNearby = true;
+                        break;
                     }
                 }
             }
 
             if (!nearbyEntities.isEmpty() || otherSubNearby) {
+                be.clearCachedWaterState();
                 be.explode(level, pos, serverParentLevel, worldPos, sub);
                 return;
             }
         }
 
-        if (sub == null)
-            return;
-
         if (level.getGameTime() - be.lastLimitCheckTick >= 20) {
             be.exceedsLimitCached = exceedsFloatBlockLimit(level, sub);
             be.lastLimitCheckTick = level.getGameTime();
         }
+
         if (be.exceedsLimitCached) {
+            be.clearCachedWaterState();
             return;
         }
-
-        Object handle = SablePhysicsHelper.getHandle(sub);
-        Vector3dc currentVel = SablePhysicsHelper.getVelocity(handle);
-        double currentVelY = (currentVel != null) ? currentVel.y() : 0;
 
         BlockPos parentPos = BlockPos.containing(worldPos.x, worldPos.y, worldPos.z);
-        double localWaterSurfaceY = -999.0;
-
-        net.minecraft.world.level.material.FluidState fluidState = com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.realFluidState(parentLevel, parentPos);
-        if (fluidState.is(FluidTags.WATER)) {
-            float h = fluidState.getHeight(parentLevel, parentPos);
-            localWaterSurfaceY = parentPos.getY() + h + countWaterAbove(parentLevel, parentPos);
-        } else {
-            BlockPos belowPos = parentPos.below();
-            net.minecraft.world.level.material.FluidState belowFluid = com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.realFluidState(parentLevel, belowPos);
-            if (belowFluid.is(FluidTags.WATER)) {
-                float h = belowFluid.getHeight(parentLevel, belowPos);
-                localWaterSurfaceY = belowPos.getY() + h + countWaterAbove(parentLevel, belowPos);
-            }
-        }
+        double localWaterSurfaceY = findWaterSurface(parentLevel, parentPos);
 
         double depth = localWaterSurfaceY - (worldPos.y - 0.5);
-        boolean isUnderWater = (depth > 0.0);
-
-        if (!isUnderWater) {
+        if (depth <= 0.0) {
+            be.clearCachedWaterState();
             return;
         }
 
-        double submergedRatio = Math.max(0.0, Math.min(1.0, depth));
-        double distanceToSurface = localWaterSurfaceY - worldPos.y;
-        double targetVelY = Math.max(-0.1, Math.min(4.0, distanceToSurface * 3.0));
+        be.cachedUnderwater = true;
+        be.cachedSubmergedRatio = Math.clamp(depth, 0.0, 1.0);
+        be.cachedDistanceToSurface = localWaterSurfaceY - worldPos.y;
+    }
 
+    private static double findWaterSurface(Level level, BlockPos pos) {
+        net.minecraft.world.level.material.FluidState fluidState =
+                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
+                        .realFluidState(level, pos);
+
+        if (fluidState.is(FluidTags.WATER)) {
+            return pos.getY()
+                    + fluidState.getHeight(level, pos)
+                    + countWaterAbove(level, pos);
+        }
+
+        BlockPos belowPos = pos.below();
+        net.minecraft.world.level.material.FluidState belowFluid =
+                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
+                        .realFluidState(level, belowPos);
+
+        if (belowFluid.is(FluidTags.WATER)) {
+            return belowPos.getY()
+                    + belowFluid.getHeight(level, belowPos)
+                    + countWaterAbove(level, belowPos);
+        }
+
+        return Double.NEGATIVE_INFINITY;
+    }
+
+    private void clearCachedWaterState() {
+        cachedUnderwater = false;
+        cachedSubmergedRatio = 0.0;
+        cachedDistanceToSurface = 0.0;
+    }
+
+    @Override
+    public void sable$physicsTick(ServerSubLevel sub, RigidBodyHandle handle, double timeStep) {
+        if (isExploded || !cachedUnderwater || exceedsLimitCached)
+            return;
+
+        if (handle == null || !handle.isValid())
+            return;
+
+        Vector3d currentVelocity = handle.getLinearVelocity(new Vector3d());
+        double currentVelY = currentVelocity.y();
+
+        double targetVelY = Math.clamp(cachedDistanceToSurface * 3.0, -0.1, 4.0);
         double perceivedVelY = Math.max(-0.5, currentVelY);
         double errorY = targetVelY - perceivedVelY;
-        double mass = SablePhysicsHelper.readMass(sub);
 
-        double forceMult = com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig.BALLAST_FORCE_MULTIPLIER.get();
-        int count = getMineCount(subId);
-        double forceToApply = ((errorY * mass * 0.8 * forceMult) * submergedRatio) / count;
+        double mass = sub.getMassTracker().getMass();
+        double forceMultiplier =
+                com.maxenonyme.createsubmarine.submarine.config.SubmarineConfig
+                        .BALLAST_FORCE_MULTIPLIER.get();
 
-        double ballastMaxForce = (16000.0 * mass * forceMult) / count;
-        forceToApply = Math.max(-ballastMaxForce, Math.min(ballastMaxForce, forceToApply));
+        int mineCount = getMineCount(sub.getUniqueId());
+        double forceY =
+                ((errorY * mass * 0.8 * forceMultiplier) * cachedSubmergedRatio)
+                        / mineCount;
 
-        if (Double.isFinite(forceToApply)) {
-            applyForce(sub, forceToApply);
+        double maxForceY = (16000.0 * mass * forceMultiplier) / mineCount;
+        forceY = Math.clamp(forceY, -maxForceY, maxForceY);
+
+        if (!Double.isFinite(forceY))
+            return;
+
+        if (Math.abs(currentVelY) < 0.01 && forceY < 0.0) {
+            forceY *= 0.1;
         }
+
+        double impulseScale = 20.0 * timeStep;
+        Vector3d worldImpulse = new Vector3d(0.0, forceY * impulseScale, 0.0);
+        Vector3d localImpulse = worldToLocal(sub, worldImpulse);
+
+        Vector3d localPoint = new Vector3d(
+                worldPosition.getX() + 0.5,
+                worldPosition.getY() + 0.5,
+                worldPosition.getZ() + 0.5);
+
+        // Mines use the floater force group because they implement the same buoyancy
+        // controller and this group is already registered
+        QueuedForceGroup forceGroup = sub.getOrCreateQueuedForceGroup(
+                CreateSubmarine.FLOATER_FORCE_GROUP.get());
+        forceGroup.applyAndRecordPointForce(localPoint, localImpulse);
+    }
+
+    private static Vector3d worldToLocal(SubLevelAccess sub, Vector3d vector) {
+        return sub.logicalPose()
+                .orientation()
+                .conjugate(new org.joml.Quaterniond())
+                .transform(vector);
     }
 
     private void explode(Level level, BlockPos pos, ServerLevel parentLevel, Vector3d worldPos, SubLevelAccess sub) {
@@ -447,22 +533,4 @@ public class UnderwaterMineBlockEntity extends BlockEntity {
         return depth;
     }
 
-    private static void applyForce(SubLevelAccess sub, double forceY) {
-        Object handle = SablePhysicsHelper.getHandle(sub);
-        if (handle == null)
-            return;
-        SablePhysicsHelper.wakeUp(handle);
-
-        double velY = 0;
-        Vector3dc vel = SablePhysicsHelper.getVelocity(handle);
-        if (vel != null)
-            velY = vel.y();
-
-        double finalForce = (Math.abs(velY) < 0.01 && forceY < 0) ? forceY * 0.1 : forceY;
-
-        Vector3d forceVec = new Vector3d(0, finalForce, 0);
-        sub.logicalPose().orientation().conjugate(new org.joml.Quaterniond()).transform(forceVec);
-
-        SablePhysicsHelper.applyLinearImpulse(handle, forceVec);
-    }
 }

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/UnderwaterMineBlockEntity.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/UnderwaterMineBlockEntity.java
@@ -231,8 +231,10 @@ public class UnderwaterMineBlockEntity extends BlockEntity
 
         BlockPos parentPos = BlockPos.containing(worldPos.x, worldPos.y, worldPos.z);
         double localWaterSurfaceY = WaterUtil.findWaterSurface(parentLevel, parentPos);
-        if (!Double.isFinite(localWaterSurfaceY))
+        if (!Double.isFinite(localWaterSurfaceY)) {
+            be.clearCachedWaterState();
             return;
+        }
 
         double depth = localWaterSurfaceY - (worldPos.y - 0.5);
         if (depth <= 0.0) {

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/UnderwaterMineBlockEntity.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/block/entity/UnderwaterMineBlockEntity.java
@@ -3,6 +3,8 @@ package com.maxenonyme.createsubmarine.submarine.block.entity;
 import com.maxenonyme.createsubmarine.CreateSubmarine;
 import com.maxenonyme.createsubmarine.submarine.system.MineOwnershipRegistry;
 import com.maxenonyme.createsubmarine.submarine.util.SubLevelRegistry;
+import com.maxenonyme.createsubmarine.submarine.util.WaterUtil;
+
 import dev.ryanhcode.sable.companion.SableCompanion;
 import dev.ryanhcode.sable.companion.SubLevelAccess;
 import dev.ryanhcode.sable.api.physics.force.QueuedForceGroup;
@@ -44,10 +46,9 @@ public class UnderwaterMineBlockEntity extends BlockEntity
     private boolean exceedsLimitCached = false;
     private long lastLimitCheckTick = -1;
 
-    // Updated by serverTick and consumed by the physics callback.
-    private volatile boolean cachedUnderwater = false;
-    private volatile double cachedSubmergedRatio = 0.0;
-    private volatile double cachedDistanceToSurface = 0.0;
+    private volatile boolean cachedUnderwater;
+    private volatile double cachedSubmergedRatio;
+    private volatile double cachedDistanceToSurface;
 
     public UnderwaterMineBlockEntity(BlockPos pos, BlockState state) {
         super(CreateSubmarine.UNDERWATER_MINE_BE.get(), pos, state);
@@ -229,7 +230,9 @@ public class UnderwaterMineBlockEntity extends BlockEntity
         }
 
         BlockPos parentPos = BlockPos.containing(worldPos.x, worldPos.y, worldPos.z);
-        double localWaterSurfaceY = findWaterSurface(parentLevel, parentPos);
+        double localWaterSurfaceY = WaterUtil.findWaterSurface(parentLevel, parentPos);
+        if (!Double.isFinite(localWaterSurfaceY))
+            return;
 
         double depth = localWaterSurfaceY - (worldPos.y - 0.5);
         if (depth <= 0.0) {
@@ -240,31 +243,6 @@ public class UnderwaterMineBlockEntity extends BlockEntity
         be.cachedUnderwater = true;
         be.cachedSubmergedRatio = Math.clamp(depth, 0.0, 1.0);
         be.cachedDistanceToSurface = localWaterSurfaceY - worldPos.y;
-    }
-
-    private static double findWaterSurface(Level level, BlockPos pos) {
-        net.minecraft.world.level.material.FluidState fluidState =
-                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
-                        .realFluidState(level, pos);
-
-        if (fluidState.is(FluidTags.WATER)) {
-            return pos.getY()
-                    + fluidState.getHeight(level, pos)
-                    + countWaterAbove(level, pos);
-        }
-
-        BlockPos belowPos = pos.below();
-        net.minecraft.world.level.material.FluidState belowFluid =
-                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
-                        .realFluidState(level, belowPos);
-
-        if (belowFluid.is(FluidTags.WATER)) {
-            return belowPos.getY()
-                    + belowFluid.getHeight(level, belowPos)
-                    + countWaterAbove(level, belowPos);
-        }
-
-        return Double.NEGATIVE_INFINITY;
     }
 
     private void clearCachedWaterState() {
@@ -310,7 +288,7 @@ public class UnderwaterMineBlockEntity extends BlockEntity
 
         double impulseScale = 20.0 * timeStep;
         Vector3d worldImpulse = new Vector3d(0.0, forceY * impulseScale, 0.0);
-        Vector3d localImpulse = worldToLocal(sub, worldImpulse);
+        Vector3d localImpulse = WaterUtil.worldToLocal(sub, worldImpulse);
 
         Vector3d localPoint = new Vector3d(
                 worldPosition.getX() + 0.5,
@@ -322,13 +300,6 @@ public class UnderwaterMineBlockEntity extends BlockEntity
         QueuedForceGroup forceGroup = sub.getOrCreateQueuedForceGroup(
                 CreateSubmarine.FLOATER_FORCE_GROUP.get());
         forceGroup.applyAndRecordPointForce(localPoint, localImpulse);
-    }
-
-    private static Vector3d worldToLocal(SubLevelAccess sub, Vector3d vector) {
-        return sub.logicalPose()
-                .orientation()
-                .conjugate(new org.joml.Quaterniond())
-                .transform(vector);
     }
 
     private void explode(Level level, BlockPos pos, ServerLevel parentLevel, Vector3d worldPos, SubLevelAccess sub) {
@@ -517,20 +488,6 @@ public class UnderwaterMineBlockEntity extends BlockEntity
             return true;
         }
         return false;
-    }
-
-    private static int countWaterAbove(Level level, BlockPos pos) {
-        int depth = 0;
-        BlockPos.MutableBlockPos m = new BlockPos.MutableBlockPos();
-        for (int y = pos.getY() + 1; y < pos.getY() + 1 + MAX_WATER_SCAN; y++) {
-            m.set(pos.getX(), y, pos.getZ());
-            if (com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.realFluidState(level, m).is(FluidTags.WATER)) {
-                depth++;
-            } else {
-                break;
-            }
-        }
-        return depth;
     }
 
 }

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/system/SteelCablePhysicsSystem.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/system/SteelCablePhysicsSystem.java
@@ -1,7 +1,5 @@
 package com.maxenonyme.createsubmarine.submarine.system;
 
-import com.maxenonyme.createsubmarine.submarine.math.OrientedBoundingBox3d;
-import com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper;
 import com.maxenonyme.createsubmarine.submarine.util.SubLevelRegistry;
 import dev.ryanhcode.sable.companion.SubLevelAccess;
 import dev.simulated_team.simulated.content.blocks.rope.strand.server.ServerLevelRopeManager;
@@ -9,7 +7,6 @@ import dev.simulated_team.simulated.content.blocks.rope.strand.server.ServerRope
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import org.joml.Quaterniond;
@@ -23,7 +20,6 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 public class SteelCablePhysicsSystem {

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/system/SubmarineSinkingSystem.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/system/SubmarineSinkingSystem.java
@@ -4,7 +4,10 @@ import com.maxenonyme.createsubmarine.CreateSubmarine;
 import com.maxenonyme.createsubmarine.submarine.compartment.CompartmentDetector;
 import com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker;
 import com.maxenonyme.createsubmarine.submarine.util.SubLevelRegistry;
+
+import dev.ryanhcode.sable.api.physics.handle.RigidBodyHandle;
 import dev.ryanhcode.sable.companion.SubLevelAccess;
+import dev.ryanhcode.sable.sublevel.ServerSubLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
@@ -186,18 +189,29 @@ public class SubmarineSinkingSystem {
     }
 
     private static void applySinkingForce(SubLevelAccess sub) {
-        Object handle = com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper.getHandle(sub);
+        if (!(sub instanceof ServerSubLevel serverSubLevel))
+            return;
+
+        RigidBodyHandle handle = RigidBodyHandle.of(serverSubLevel);
         if (handle == null) return;
-        double mass = com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper.readMass(sub);
+
+        double mass = serverSubLevel.getMassTracker().getMass();
         double force = Math.max(mass * 18.0, 3000.0);
-        com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper.applyLinearImpulse(handle, new Vector3d(
+        double spin = mass * 8.0;
+
+        // This can be changed to a forceGroup if it needs to be shown;
+
+        handle.applyLinearAndAngularImpulse(
+            new Vector3d(
                 (RAND.nextDouble() - 0.5) * force * 0.6,
                 -force,
-                (RAND.nextDouble() - 0.5) * force * 0.6));
-        double spin = mass * 8.0;
-        com.maxenonyme.createsubmarine.submarine.util.SablePhysicsHelper.applyAngularImpulse(handle, new Vector3d(
+                (RAND.nextDouble() - 0.5) * force * 0.6
+            ), 
+            new Vector3d(
                 (RAND.nextDouble() - 0.5) * spin,
                 (RAND.nextDouble() - 0.5) * spin * 0.3,
-                (RAND.nextDouble() - 0.5) * spin));
+                (RAND.nextDouble() - 0.5) * spin
+            )
+        );
     }
 }

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/util/WaterUtil.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/util/WaterUtil.java
@@ -2,9 +2,14 @@ package com.maxenonyme.createsubmarine.submarine.util;
 
 import org.joml.Vector3d;
 
+import com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker;
+
 import dev.ryanhcode.sable.companion.SubLevelAccess;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.tags.FluidTags;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.FluidState;
 
 public class WaterUtil {
     public static Vector3d worldToLocal(SubLevelAccess sub, Vector3d vector) {
@@ -15,29 +20,38 @@ public class WaterUtil {
     }
 
     public static double findWaterSurface(Level level, BlockPos pos) {
-        net.minecraft.world.level.material.FluidState fluidState =
-                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
-                        .realFluidState(level, pos);
-        if (fluidState.is(net.minecraft.tags.FluidTags.WATER)) {
-            return pos.getY() + fluidState.getHeight(level, pos) + countWaterAbove(level, pos);
+        BlockPos.MutableBlockPos cursor = pos.mutable();
+        FluidState fluid = CompartmentTracker.realFluidState(level, cursor);
+
+        if (!fluid.is(FluidTags.WATER)) {
+            cursor.move(Direction.DOWN);
+            fluid = CompartmentTracker.realFluidState(level, cursor);
+
+            if (!fluid.is(FluidTags.WATER)) {
+                return Double.NaN;
+            }
         }
 
-        BlockPos belowPos = pos.below();
-        net.minecraft.world.level.material.FluidState belowFluid =
-                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
-                        .realFluidState(level, belowPos);
-        if (belowFluid.is(net.minecraft.tags.FluidTags.WATER)) {
-            return belowPos.getY() + belowFluid.getHeight(level, belowPos)
-                    + countWaterAbove(level, belowPos);
+        while (cursor.getY() + 1 < level.getMaxBuildHeight()) {
+            BlockPos.MutableBlockPos above = cursor.mutable().move(Direction.UP);
+            FluidState fluidAbove =
+                    CompartmentTracker.realFluidState(level, above);
+
+            if (!fluidAbove.is(FluidTags.WATER)) {
+                break;
+            }
+
+            cursor.set(above);
+            fluid = fluidAbove;
         }
 
-        return Double.NaN;
+        return cursor.getY() + fluid.getHeight(level, cursor);
     }
 
     public static int countWaterAbove(Level level, BlockPos pos) {
         int depth = 0;
         BlockPos.MutableBlockPos m = new BlockPos.MutableBlockPos();
-        for (int y = pos.getY() + 1; y < pos.getY() + 1 + level.getMaxBuildHeight(); y++) {
+        for (int y = pos.getY() + 1; y < level.getMaxBuildHeight(); y++) {
             m.set(pos.getX(), y, pos.getZ());
             if (com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.realFluidState(level, m)
                     .is(net.minecraft.tags.FluidTags.WATER)) {

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/util/WaterUtil.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/util/WaterUtil.java
@@ -37,7 +37,7 @@ public class WaterUtil {
     public static int countWaterAbove(Level level, BlockPos pos) {
         int depth = 0;
         BlockPos.MutableBlockPos m = new BlockPos.MutableBlockPos();
-        for (int y = pos.getY() + 1; y < pos.getY() + 1 + 200; y++) {
+        for (int y = pos.getY() + 1; y < pos.getY() + 1 + level.getMaxBuildHeight(); y++) {
             m.set(pos.getX(), y, pos.getZ());
             if (com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.realFluidState(level, m)
                     .is(net.minecraft.tags.FluidTags.WATER)) {

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/util/WaterUtil.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/util/WaterUtil.java
@@ -1,0 +1,51 @@
+package com.maxenonyme.createsubmarine.submarine.util;
+
+import org.joml.Vector3d;
+
+import dev.ryanhcode.sable.companion.SubLevelAccess;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+
+public class WaterUtil {
+    public static Vector3d worldToLocal(SubLevelAccess sub, Vector3d vector) {
+        return sub.logicalPose()
+                .orientation()
+                .conjugate(new org.joml.Quaterniond())
+                .transform(vector);
+    }
+
+    public static double findWaterSurface(Level level, BlockPos pos) {
+        net.minecraft.world.level.material.FluidState fluidState =
+                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
+                        .realFluidState(level, pos);
+        if (fluidState.is(net.minecraft.tags.FluidTags.WATER)) {
+            return pos.getY() + fluidState.getHeight(level, pos) + countWaterAbove(level, pos);
+        }
+
+        BlockPos belowPos = pos.below();
+        net.minecraft.world.level.material.FluidState belowFluid =
+                com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker
+                        .realFluidState(level, belowPos);
+        if (belowFluid.is(net.minecraft.tags.FluidTags.WATER)) {
+            return belowPos.getY() + belowFluid.getHeight(level, belowPos)
+                    + countWaterAbove(level, belowPos);
+        }
+
+        return Double.NaN;
+    }
+
+    public static int countWaterAbove(Level level, BlockPos pos) {
+        int depth = 0;
+        BlockPos.MutableBlockPos m = new BlockPos.MutableBlockPos();
+        for (int y = pos.getY() + 1; y < pos.getY() + 1 + 200; y++) {
+            m.set(pos.getX(), y, pos.getZ());
+            if (com.maxenonyme.createsubmarine.submarine.compartment.CompartmentTracker.realFluidState(level, m)
+                    .is(net.minecraft.tags.FluidTags.WATER)) {
+                depth++;
+            } else {
+                break;
+            }
+        }
+        return depth;
+    }
+}


### PR DESCRIPTION
Changed SablePhysicsHelper to QueuedForceGroup, this allows for the forces to be applied at the correct location

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches buoyancy, drag, and sinking to Sable queued forces with per-point, timestep‑scaled impulses. Adds `WaterUtil` for reliable water-surface detection and world→local transforms, and fixes horizontal drag using mass from the sublevel tracker.

- **Refactors**
  - Cache underwater state, submerged ratio, and distance-to-surface in the server tick; apply impulses in `sable$physicsTick`.
  - Use `QueuedForceGroup` (`CreateSubmarine.BALLAST_FORCE_GROUP`, `CreateSubmarine.FLOATER_FORCE_GROUP`) for per-tank/floater/mine local impulses; scale by `20*timeStep`; soften downward force near rest; clamp mine force; apply once-per-tick horizontal drag via mass tracker at the cluster center.
  - Replace `SablePhysicsHelper` with `RigidBodyHandle`; read mass via `ServerSubLevel` mass tracker.
  - Add `WaterUtil` (`findWaterSurface`, `worldToLocal`, `countWaterAbove`) to centralize water checks and transforms.
  - Update `SubmarineSinkingSystem` to `handle.applyLinearAndAngularImpulse`; make `UnderwaterMineBlockEntity` a `BlockEntitySubLevelActor` and queue its buoyancy in the floater group.

- **Dependencies**
  - Replace Create dependency with `maven.modrinth:create:6.0.10+mc1.21.1`.
  - Bump NeoForge to `21.1.228`.

<sup>Written for commit 808f742e7800ffd86b4de87d4d2983d70214b1a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MaxCreateMC/Create-Deep-Seas/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

