### PR TITLE
Add compatibility for `Goggles in Creative mode`

### DIFF
--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/client/CreateSubmarineClientEvents.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/client/CreateSubmarineClientEvents.java
@@ -13,6 +13,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.ChatFormatting;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.client.Minecraft;
+import com.simibubi.create.content.equipment.goggles.GogglesItem;
 
 @EventBusSubscriber(modid = CreateSubmarine.MOD_ID, value = Dist.CLIENT)
 public class CreateSubmarineClientEvents {
@@ -21,17 +23,7 @@ public class CreateSubmarineClientEvents {
     public static void onTooltip(ItemTooltipEvent event) {
         if (event.getEntity() == null)
             return;
-
-        boolean hasGoggles = false;
-        var headSlot = event.getEntity().getInventory().getArmor(3);
-        if (headSlot != null && !headSlot.isEmpty()) {
-            ResourceLocation id = BuiltInRegistries.ITEM.getKey(headSlot.getItem());
-            if (id != null && id.getNamespace().equals("create") && id.getPath().contains("goggles")) {
-                hasGoggles = true;
-            }
-        }
-
-        if (!hasGoggles)
+        if (!GogglesItem.isWearingGoggles(Minecraft.getInstance().player))
             return;
 
         if (event.getItemStack().getItem() instanceof BlockItem blockItem) {

--- a/src/main/java/com/maxenonyme/createsubmarine/submarine/client/CreateSubmarineClientEvents.java
+++ b/src/main/java/com/maxenonyme/createsubmarine/submarine/client/CreateSubmarineClientEvents.java
@@ -23,7 +23,8 @@ public class CreateSubmarineClientEvents {
     public static void onTooltip(ItemTooltipEvent event) {
         if (event.getEntity() == null)
             return;
-        if (!GogglesItem.isWearingGoggles(Minecraft.getInstance().player))
+        if (!(event.getEntity() instanceof Player player) || !GogglesItem.isWearingGoggles(player))
+            return;
             return;
 
         if (event.getItemStack().getItem() instanceof BlockItem blockItem) {


### PR DESCRIPTION
Add compatibility for `Goggles in Creative mode`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tooltip gating respect Create’s goggles logic, including `Goggles in Creative mode`. Previously we parsed the head slot for a “create:goggles”-like item; now we use `GogglesItem.isWearingGoggles()`, enabling Creative compatibility and eliminating false positives from loosely named items.

- Derives the player from the tooltip event entity via an `instanceof` check instead of `Minecraft.getInstance().player()`, so gating tracks the viewer.
- Replaces manual registry checks with the Create API; imports `Minecraft` and `GogglesItem`. A redundant `return;` remains after the new guard clause.

<sup>Written for commit cf117c916623af385cf89c67a95a2aebedd6ce48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MaxCreateMC/Create-Deep-Seas/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

